### PR TITLE
D-6 logger adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `phalcon/debugbar` are documented here. The format is based on [Keep a Changelog][keep_a_changelog] and this project adheres to [Semantic Versioning][semantic_versioning].
 
+## [0.3.0](https://github.com/phalcon/debugbar/releases/tag/v0.3.0) (2026-07-14)
+
+### Changed
+
+### Added
+
+- A `logger` collector and `Phalcon\DebugBar\Logger\Adapter`. Attach the adapter to the application logger and every item logged through `Phalcon\Logger` is captured in the bar's "Logs" tab, separate from the manual `messages` collector. Each entry keeps the log level, message, and PSR-3 context; the context renders as a collapsible, pretty-printed JSON detail. Forwarding runs through the new `DebugBar::addLog()` and no-ops when the collector is disabled.
+
+### Fixed
+
+### Removed
+
 ## [0.2.0](https://github.com/phalcon/debugbar/releases/tag/v0.2.0) (2026-07-13)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A web debug bar and debugger for the [Phalcon Framework](https://phalcon.io) -
 a status bar injected into your application's HTML that surfaces per-request
-diagnostics (messages, timing, database queries, request, route, and more),
+diagnostics (messages, logs, timing, database queries, request, route, and more),
 plus the migrated Phalcon debug/exception page.
 
 > **Status:** under active development. Fork of

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,11 +91,12 @@ use Phalcon\DebugBar\Provider;
 
 ## Collectors
 
-Each collector contributes one tab. A collector reads its data in one of three ways:
+Each collector contributes one tab. A collector reads its data in one of four ways:
 
 - **Snapshot** - reads state when the response is assembled.
 - **Streamed** - subscribes to framework events and accumulates as they fire.
 - **Manual** - fed through the `Debug` facade.
+- **Adapter** - captured from a `Phalcon\Logger` through the debug bar's logger adapter.
 
 | Name         | Source                                                   | Inflow            |
 |--------------|----------------------------------------------------------|-------------------|
@@ -103,6 +104,7 @@ Each collector contributes one tab. A collector reads its data in one of three w
 | `config`     | The `config` service, flattened and redacted             | snapshot          |
 | `database`   | SQL statements, bound parameters, and timings            | streamed          |
 | `exceptions` | Throwables, with stack traces                            | manual + streamed |
+| `logger`     | Log entries captured from a `Phalcon\Logger` adapter     | adapter           |
 | `messages`   | Messages recorded through the facade                     | manual            |
 | `request`    | Request method, URI, query, post, and headers (redacted) | snapshot          |
 | `route`      | Matched module, controller, action, and parameters       | streamed          |
@@ -171,6 +173,44 @@ try {
 
 The `exceptions` collector also captures throwables automatically. It subscribes to `dispatch:beforeException`, records the throwable, and leaves it to bubble - the bar never handles or swallows it. A throwable appears in the panel only when the request still finishes with a rendered response; a caught exception, or one the application forwards to an error page, qualifies, while a fully unhandled one aborts before the bar renders.
 
+## Capturing Logs
+
+`Phalcon\DebugBar\Logger\Adapter` is a `Phalcon\Logger` adapter. Attach it to the application logger and every logged item is captured in the bar's `logger` collector, shown in the "Logs" tab. This is separate from the `messages` collector: `logger` is the automatic application log, while `messages` is what the code records by hand through the `Debug` facade.
+
+- Phalcon 5 (the C extension) exposes the `Phalcon\Logger` adapter contract the adapter builds on.
+- Phalcon 6 (`phalcon/phalcon`) exposes the same contract. The adapter attaches the same way on either runtime.
+
+The adapter forwards each `Phalcon\Logger\Item` to the active bar through `Phalcon\DebugBar\Debug::getBar()`, reading the item's level name, message, and PSR-3 context. Forwarding no-ops when the `logger` collector is absent or disabled, so the adapter is safe to leave attached. The adapter also accepts a `null` bar - which `Debug::getBar()` returns until the bar boots - so it can be attached unconditionally.
+
+```php
+<?php
+
+use Phalcon\DebugBar\Debug;
+use Phalcon\DebugBar\Logger\Adapter;
+use Phalcon\Logger\Adapter\Stream;
+use Phalcon\Logger\Logger;
+
+$logger = new Logger('messages', ['main' => new Stream('/var/log/app.log')]);
+$logger->addAdapter('debugbar', new Adapter(Debug::getBar()));
+
+$logger->info('user login', ['user_id' => 42]);
+$logger->error('payment declined', ['order_id' => 1001]);
+```
+
+Each entry keeps its log level as the label and its message beside it. An entry logged with PSR-3 context becomes collapsible: the level and message stay visible and expand to the context, rendered as pretty-printed JSON. An entry logged without context renders as a plain row.
+
+The `logger` collector is registered by default. Disable it, like any collector, through the `collectors` key:
+
+```php
+<?php
+
+use Phalcon\DebugBar\Provider;
+
+(new Provider($application, [
+    'collectors' => ['logger' => false],
+]))->boot();
+```
+
 ## Redaction and Access Control
 
 `Phalcon\DebugBar\Security\Redactor` guards data before it leaves PHP. It matches keys case-insensitively through nested arrays and applies two tiers:
@@ -205,5 +245,6 @@ The bar sits at the bottom of the page. Each collector is a tab; a tab shows a b
 - **grid** panels (version, request, config, session, route) render a key and value table.
 - **list** panels (time, messages, database, view, cache) render labelled rows.
 - **exceptions** panels render one collapsible entry per throwable; the summary line stays visible and expands to the stack trace.
+- **logs** panels (logger) render one entry per logged item; an entry with context is collapsible - the level and message stay visible and expand to the context.
 
 A handle at the right of the tab row collapses the whole bar to a corner button, so it never covers the host page's own controls. The collapsed state is remembered across page loads.

--- a/resources/assets/debugbar.css
+++ b/resources/assets/debugbar.css
@@ -183,3 +183,30 @@
     white-space: pre-wrap;
     word-break: break-word;
 }
+
+#phalcon-debugbar .phalcon-debugbar-log {
+    padding: 3px 0;
+    border-bottom: 1px solid #23233440;
+}
+
+#phalcon-debugbar .phalcon-debugbar-log-summary {
+    padding: 4px 0;
+    cursor: pointer;
+}
+
+#phalcon-debugbar .phalcon-debugbar-log-label {
+    margin-right: 8px;
+    color: #7cc4ff;
+    font-weight: 600;
+}
+
+#phalcon-debugbar .phalcon-debugbar-log-context {
+    margin: 6px 0 10px 16px;
+    padding: 8px 10px;
+    background: #0f0f17;
+    border-radius: 4px;
+    color: #b9b9d4;
+    font-size: 11px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -49,8 +49,13 @@
             return 'html';
         }
         if (Array.isArray(panel)) {
-            if (panel.length && panel[0] && typeof panel[0] === 'object' && 'trace' in panel[0]) {
-                return 'exceptions';
+            if (panel.length && panel[0] && typeof panel[0] === 'object') {
+                if ('trace' in panel[0]) {
+                    return 'exceptions';
+                }
+                if ('context' in panel[0]) {
+                    return 'logs';
+                }
             }
             return 'list';
         }
@@ -126,6 +131,32 @@
         return wrap;
     }
 
+    function renderLogs(panel) {
+        if (!Array.isArray(panel) || !panel.length) {
+            return el('div', 'phalcon-debugbar-empty', 'No data');
+        }
+        var wrap = el('div', 'phalcon-debugbar-logs');
+        panel.forEach(function (row) {
+            row = row || {};
+            var context = scalar(row.context);
+            if (context === '') {
+                var line = el('div', 'phalcon-debugbar-log');
+                line.appendChild(el('span', 'phalcon-debugbar-log-label', scalar(row.label)));
+                line.appendChild(el('span', 'phalcon-debugbar-log-message', scalar(row.message)));
+                wrap.appendChild(line);
+                return;
+            }
+            var details = el('details', 'phalcon-debugbar-log');
+            var summary = el('summary', 'phalcon-debugbar-log-summary');
+            summary.appendChild(el('span', 'phalcon-debugbar-log-label', scalar(row.label)));
+            summary.appendChild(el('span', 'phalcon-debugbar-log-message', scalar(row.message)));
+            details.appendChild(summary);
+            details.appendChild(el('pre', 'phalcon-debugbar-log-context', context));
+            wrap.appendChild(details);
+        });
+        return wrap;
+    }
+
     function renderPanel(type, panel) {
         switch (type) {
             case 'list':
@@ -136,6 +167,8 @@
                 return renderHtml(panel);
             case 'exceptions':
                 return renderExceptions(panel);
+            case 'logs':
+                return renderLogs(panel);
             case 'grid':
             default:
                 return renderGrid(panel);

--- a/src/DebugBar/Collector/LoggerCollector.php
+++ b/src/DebugBar/Collector/LoggerCollector.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\Collector;
+
+use Phalcon\DebugBar\Contracts\LoggerAware;
+use Phalcon\DebugBar\DebugBarTypes;
+
+use function count;
+use function is_string;
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Accumulates entries captured from a `Phalcon\Logger` through the logger
+ * adapter. Distinct from `MessagesCollector`: this is the automatic, level
+ * tagged application log, not the manual `Debug::info()`/`debug()`/… messages
+ * the developer drops in by hand.
+ *
+ * Each entry carries the log level, the message, and the PSR-3 context, which
+ * the `logs` panel shows as a collapsible detail per row.
+ *
+ * @phpstan-import-type log_envelope from DebugBarTypes
+ * @phpstan-import-type log_panel from DebugBarTypes
+ */
+final class LoggerCollector extends AbstractCollector implements LoggerAware
+{
+    public const NAME = 'logger';
+
+    /**
+     * @var string
+     */
+    protected string $icon = 'icon-messages';
+
+    /**
+     * @var string
+     */
+    protected string $label = 'Logs';
+
+    /**
+     * @var string
+     */
+    protected string $panel = 'logs';
+
+    /**
+     * @var log_panel
+     */
+    private array $logs = [];
+
+    /**
+     * @param string                  $message
+     * @param string                  $level
+     * @param array<array-key, mixed> $context
+     *
+     * @return void
+     */
+    public function addLog(string $message, string $level, array $context = []): void
+    {
+        $this->logs[] = [
+            'label'   => $level,
+            'message' => $message,
+            'context' => $this->stringifyContext($context),
+        ];
+    }
+
+    /**
+     * @return log_envelope
+     */
+    public function collect(): array
+    {
+        return [
+            'panel' => $this->logs,
+            'badge' => count($this->logs),
+        ];
+    }
+
+    /**
+     * Renders the PSR-3 context as pretty-printed JSON for the panel's
+     * collapsible detail. An empty context yields an empty string, which the
+     * renderer shows as a plain (non-collapsible) row.
+     *
+     * @param array<array-key, mixed> $context
+     *
+     * @return string
+     */
+    private function stringifyContext(array $context): string
+    {
+        if ([] === $context) {
+            return '';
+        }
+
+        $json = json_encode(
+            $context,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+
+        return is_string($json) ? $json : '';
+    }
+}

--- a/src/DebugBar/Contracts/LoggerAware.php
+++ b/src/DebugBar/Contracts/LoggerAware.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\Contracts;
+
+/**
+ * Implemented by a collector that accepts application log entries, so the
+ * DebugBar `addLog()` method (and the logger adapter that drives it) can
+ * delegate to it.
+ */
+interface LoggerAware
+{
+    /**
+     * @param string                  $message
+     * @param string                  $level
+     * @param array<array-key, mixed> $context
+     *
+     * @return void
+     */
+    public function addLog(string $message, string $level, array $context = []): void;
+}

--- a/src/DebugBar/DebugBar.php
+++ b/src/DebugBar/DebugBar.php
@@ -15,6 +15,7 @@ namespace Phalcon\DebugBar;
 
 use Phalcon\DebugBar\Contracts\Collector;
 use Phalcon\DebugBar\Contracts\ExceptionAware;
+use Phalcon\DebugBar\Contracts\LoggerAware;
 use Phalcon\DebugBar\Contracts\MessageAware;
 use Phalcon\DebugBar\Contracts\TimeAware;
 use Phalcon\DebugBar\Exceptions\Exception;
@@ -72,6 +73,23 @@ class DebugBar
         $collector = $this->collectors['exceptions'] ?? null;
         if ($collector instanceof ExceptionAware) {
             $collector->addThrowable($throwable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string                  $message
+     * @param string                  $level
+     * @param array<array-key, mixed> $context
+     *
+     * @return static
+     */
+    public function addLog(string $message, string $level, array $context = []): static
+    {
+        $collector = $this->collectors['logger'] ?? null;
+        if ($collector instanceof LoggerAware) {
+            $collector->addLog($message, $level, $context);
         }
 
         return $this;

--- a/src/DebugBar/DebugBarTypes.php
+++ b/src/DebugBar/DebugBarTypes.php
@@ -22,11 +22,14 @@ namespace Phalcon\DebugBar;
  * @phpstan-type grid_panel array<string, scalar>
  * @phpstan-type exception_row array{label: string, message: string, trace: string}
  * @phpstan-type exception_panel list<exception_row>
+ * @phpstan-type log_row array{label: string, message: string, context: string}
+ * @phpstan-type log_panel list<log_row>
  * @phpstan-type widget array{label: string, icon: string, panel: string}
  * @phpstan-type envelope array{panel: mixed, badge: scalar|null}
  * @phpstan-type list_envelope array{panel: list_panel, badge: scalar|null}
  * @phpstan-type grid_envelope array{panel: grid_panel, badge: scalar|null}
  * @phpstan-type exception_envelope array{panel: exception_panel, badge: scalar|null}
+ * @phpstan-type log_envelope array{panel: log_panel, badge: scalar|null}
  * @phpstan-type payload array{data: array<string, envelope>, meta: array<string, mixed>}
  */
 final class DebugBarTypes

--- a/src/DebugBar/Logger/Adapter.php
+++ b/src/DebugBar/Logger/Adapter.php
@@ -26,16 +26,18 @@ use Phalcon\Logger\Item;
  * $logger->addAdapter('debugbar', new Adapter(Debug::getBar()));
  * ```
  *
- * Forwarding goes through `DebugBar::addLog()`, so it safely no-ops when the
- * logger collector is disabled. Only `process()` is overridden; the inherited
- * `commit()` replays queued items through it, covering transactional logging.
+ * The bar is nullable because `Debug::getBar()` returns `null` until the bar
+ * boots, so the adapter can be attached unconditionally. Forwarding goes
+ * through `DebugBar::addLog()`, so it also no-ops when the logger collector is
+ * disabled. Only `process()` is overridden; the inherited `commit()` replays
+ * queued items through it, covering transactional logging.
  */
 final class Adapter extends AbstractAdapter
 {
     /**
-     * @param DebugBar $bar
+     * @param DebugBar|null $bar
      */
-    public function __construct(private readonly DebugBar $bar)
+    public function __construct(private readonly ?DebugBar $bar = null)
     {
     }
 
@@ -54,6 +56,6 @@ final class Adapter extends AbstractAdapter
      */
     public function process(Item $item): void
     {
-        $this->bar->addLog($item->getMessage(), $item->getLevelName(), $item->getContext());
+        $this->bar?->addLog($item->getMessage(), $item->getLevelName(), $item->getContext());
     }
 }

--- a/src/DebugBar/Logger/Adapter.php
+++ b/src/DebugBar/Logger/Adapter.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\Logger;
+
+use Phalcon\DebugBar\DebugBar;
+use Phalcon\Logger\Adapter\AbstractAdapter;
+use Phalcon\Logger\Item;
+
+/**
+ * A `Phalcon\Logger` adapter that forwards every logged item to the debug bar's
+ * `LoggerCollector`. Attach it to the application logger and its output is
+ * captured in the bar's "Logs" tab:
+ *
+ * ```php
+ * $logger->addAdapter('debugbar', new Adapter(Debug::getBar()));
+ * ```
+ *
+ * Forwarding goes through `DebugBar::addLog()`, so it safely no-ops when the
+ * logger collector is disabled. Only `process()` is overridden; the inherited
+ * `commit()` replays queued items through it, covering transactional logging.
+ */
+final class Adapter extends AbstractAdapter
+{
+    /**
+     * @param DebugBar $bar
+     */
+    public function __construct(private readonly DebugBar $bar)
+    {
+    }
+
+    /**
+     * @return bool
+     */
+    public function close(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param Item $item
+     *
+     * @return void
+     */
+    public function process(Item $item): void
+    {
+        $this->bar->addLog($item->getMessage(), $item->getLevelName(), $item->getContext());
+    }
+}

--- a/src/DebugBar/Provider.php
+++ b/src/DebugBar/Provider.php
@@ -19,6 +19,7 @@ use Phalcon\DebugBar\Collector\CacheCollector;
 use Phalcon\DebugBar\Collector\ConfigCollector;
 use Phalcon\DebugBar\Collector\DatabaseCollector;
 use Phalcon\DebugBar\Collector\ExceptionsCollector;
+use Phalcon\DebugBar\Collector\LoggerCollector;
 use Phalcon\DebugBar\Collector\MessagesCollector;
 use Phalcon\DebugBar\Collector\RequestCollector;
 use Phalcon\DebugBar\Collector\RouteCollector;
@@ -224,6 +225,10 @@ class Provider
 
         if ($this->isCollectorEnabled(MessagesCollector::NAME)) {
             $collectors[] = new MessagesCollector();
+        }
+
+        if ($this->isCollectorEnabled(LoggerCollector::NAME)) {
+            $collectors[] = new LoggerCollector();
         }
 
         if ($this->isCollectorEnabled(ExceptionsCollector::NAME)) {

--- a/tests/Unit/DebugBar/Collector/LoggerCollectorTest.php
+++ b/tests/Unit/DebugBar/Collector/LoggerCollectorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\DebugBar\Collector;
+
+use Phalcon\DebugBar\Collector\LoggerCollector;
+use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use Phalcon\Tests\Support\DebugBar\PanelContractTrait;
+
+use function json_decode;
+
+final class LoggerCollectorTest extends AbstractUnitTestCase
+{
+    use PanelContractTrait;
+
+    public function testContextIsCapturedAsJson(): void
+    {
+        $collector = new LoggerCollector();
+        $collector->addLog('user login', 'info', ['user_id' => 42, 'ip' => '10.0.0.1']);
+
+        $context = $collector->collect()['panel'][0]['context'];
+
+        $this->assertSame(['user_id' => 42, 'ip' => '10.0.0.1'], json_decode($context, true));
+    }
+
+    public function testEmptyContextIsAnEmptyString(): void
+    {
+        $collector = new LoggerCollector();
+        $collector->addLog('ping', 'debug');
+
+        $this->assertSame('', $collector->collect()['panel'][0]['context']);
+    }
+
+    public function testLogsAccumulateWithLevelAsLabel(): void
+    {
+        $collector = new LoggerCollector();
+        $collector->addLog('user created', 'info');
+        $collector->addLog('disk full', 'error');
+
+        $envelope = $collector->collect();
+
+        $this->assertSame(2, $envelope['badge']);
+        $this->assertSame('info', $envelope['panel'][0]['label']);
+        $this->assertSame('user created', $envelope['panel'][0]['message']);
+        $this->assertSame('error', $envelope['panel'][1]['label']);
+        $this->assertSame('disk full', $envelope['panel'][1]['message']);
+    }
+
+    public function testNameAndPanelContract(): void
+    {
+        $collector = new LoggerCollector();
+        $collector->addLog('x', 'debug', ['k' => 'v']);
+
+        $this->assertSame('logger', $collector->getName());
+        $this->assertSame('logs', $collector->getWidget()['panel']);
+        $this->assertPanelContract($collector);
+    }
+}

--- a/tests/Unit/DebugBar/DebugBarConvenienceTest.php
+++ b/tests/Unit/DebugBar/DebugBarConvenienceTest.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\DebugBar;
 
+use Phalcon\DebugBar\Collector\LoggerCollector;
 use Phalcon\DebugBar\DebugBar;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Tests\Support\DebugBar\Fixtures\RecordingExceptionsCollector;
 use Phalcon\Tests\Support\DebugBar\Fixtures\RecordingMessagesCollector;
 use Phalcon\Tests\Support\DebugBar\Fixtures\RecordingTimeCollector;
 use RuntimeException;
+
+use function json_decode;
 
 final class DebugBarConvenienceTest extends AbstractUnitTestCase
 {
@@ -33,6 +36,23 @@ final class DebugBarConvenienceTest extends AbstractUnitTestCase
         $this->assertCount(1, $exceptions->getThrowables());
     }
 
+    public function testAddLogDelegatesToLoggerCollector(): void
+    {
+        $logger = new LoggerCollector();
+        $bar    = new DebugBar();
+        $bar->addCollector($logger);
+
+        $bar->addLog('hello', 'info')
+            ->addLog('boom', 'error', ['code' => 42]);
+
+        $panel = $logger->collect()['panel'];
+
+        $this->assertCount(2, $panel);
+        $this->assertSame(['label' => 'info', 'message' => 'hello', 'context' => ''], $panel[0]);
+        $this->assertSame('error', $panel[1]['label']);
+        $this->assertSame(['code' => 42], json_decode($panel[1]['context'], true));
+    }
+
     public function testConvenienceMethodsNoOpWhenCollectorsAbsent(): void
     {
         $bar = new DebugBar();
@@ -45,6 +65,7 @@ final class DebugBarConvenienceTest extends AbstractUnitTestCase
                 ->notice('d')
                 ->warning('e')
                 ->error('f')
+                ->addLog('g', 'info')
                 ->startMeasure('boot')
                 ->stopMeasure('boot')
                 ->addException(new RuntimeException('boom'))

--- a/tests/Unit/DebugBar/Logger/AdapterTest.php
+++ b/tests/Unit/DebugBar/Logger/AdapterTest.php
@@ -84,4 +84,13 @@ final class AdapterTest extends AbstractUnitTestCase
         $this->assertSame('boom', $row['message']);
         $this->assertSame(['request_id' => 'abc'], json_decode($row['context'], true));
     }
+
+    public function testProcessNoOpsWhenBarIsNull(): void
+    {
+        $adapter = new Adapter(null);
+
+        $adapter->process(new Item('boom', 'error', 3, new DateTimeImmutable()));
+
+        $this->assertTrue($adapter->close());
+    }
 }

--- a/tests/Unit/DebugBar/Logger/AdapterTest.php
+++ b/tests/Unit/DebugBar/Logger/AdapterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\DebugBar\Logger;
+
+use DateTimeImmutable;
+use Phalcon\DebugBar\Collector\LoggerCollector;
+use Phalcon\DebugBar\DebugBar;
+use Phalcon\DebugBar\Logger\Adapter;
+use Phalcon\Logger\Item;
+use Phalcon\Logger\Logger;
+use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+
+use function json_decode;
+
+final class AdapterTest extends AbstractUnitTestCase
+{
+    public function testCloseReturnsTrue(): void
+    {
+        $adapter = new Adapter(new DebugBar());
+
+        $this->assertTrue($adapter->close());
+    }
+
+    public function testLoggerContextIsForwarded(): void
+    {
+        $collector = new LoggerCollector();
+        $bar       = new DebugBar();
+        $bar->addCollector($collector);
+
+        $logger = new Logger('debug', ['debugbar' => new Adapter($bar)]);
+        $logger->info('user login', ['user_id' => 7]);
+
+        $row = $collector->collect()['panel'][0];
+
+        $this->assertSame('user login', $row['message']);
+        $this->assertSame(['user_id' => 7], json_decode($row['context'], true));
+    }
+
+    public function testLoggingThroughRealLoggerPopulatesTheCollector(): void
+    {
+        $collector = new LoggerCollector();
+        $bar       = new DebugBar();
+        $bar->addCollector($collector);
+
+        $logger = new Logger('debug', ['debugbar' => new Adapter($bar)]);
+        $logger->info('hello');
+        $logger->error('nope');
+
+        $panel = $collector->collect()['panel'];
+
+        $this->assertCount(2, $panel);
+        $this->assertSame('info', $panel[0]['label']);
+        $this->assertSame('hello', $panel[0]['message']);
+        $this->assertSame('', $panel[0]['context']);
+        $this->assertSame('error', $panel[1]['label']);
+        $this->assertSame('nope', $panel[1]['message']);
+    }
+
+    public function testProcessForwardsMessageLevelAndContext(): void
+    {
+        $collector = new LoggerCollector();
+        $bar       = new DebugBar();
+        $bar->addCollector($collector);
+
+        $adapter = new Adapter($bar);
+        $adapter->process(
+            new Item('boom', 'error', 3, new DateTimeImmutable(), ['request_id' => 'abc'])
+        );
+
+        $row = $collector->collect()['panel'][0];
+
+        $this->assertSame('error', $row['label']);
+        $this->assertSame('boom', $row['message']);
+        $this->assertSame(['request_id' => 'abc'], json_decode($row['context'], true));
+    }
+}

--- a/tests/Unit/DebugBar/ProviderTest.php
+++ b/tests/Unit/DebugBar/ProviderTest.php
@@ -161,6 +161,7 @@ final class ProviderTest extends AbstractUnitTestCase
             [
                 'version',
                 'messages',
+                'logger',
                 'exceptions',
                 'time',
                 'database',

--- a/tests/support/DebugBar/PanelContractTrait.php
+++ b/tests/support/DebugBar/PanelContractTrait.php
@@ -53,6 +53,15 @@ trait PanelContractTrait
                 }
 
                 break;
+            case 'logs':
+                Assert::assertIsArray($data);
+                foreach ($data as $row) {
+                    Assert::assertIsArray($row);
+                    Assert::assertArrayHasKey('message', $row);
+                    Assert::assertArrayHasKey('context', $row);
+                }
+
+                break;
             case 'code':
                 Assert::assertIsArray($data);
                 Assert::assertArrayHasKey('source', $data);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #6 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/debugbar/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the documentation about this change

Added a `logger` collector and `Phalcon\DebugBar\Logger\Adapter`. Attach the adapter to the application logger and every item logged through `Phalcon\Logger` is captured in the bar's "Logs" tab, separate from the manual `messages` collector. Each entry keeps the log level, message, and PSR-3 context; the context renders as a collapsible, pretty-printed JSON detail. Forwarding runs through the new `DebugBar::addLog()` and no-ops when the collector is disabled.

Thanks
