### PR TITLE
Add database query summary metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `phalcon/debugbar` are documented here. The format is bas
 
 ### Added
 
-- Optional collector summaries rendered as headline metrics above a panel. The database collector uses them to report total queries, duplicate executions, and accumulated SQL time, and marks statements belonging to a duplicate group.
+- Optional, extensible collector summaries rendered as headline metrics above a panel. The database collector uses them to report total queries, duplicate executions, and accumulated SQL time, and marks repeated statements with their execution count.
 
 ## [0.4.0](https://github.com/phalcon/debugbar/releases/tag/v0.4.0) (2026-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `phalcon/debugbar` are documented here. The format is bas
 
 ### Added
 
-- Optional, extensible collector summaries rendered as headline metrics above a panel. The database collector uses them to report total queries, duplicate executions, and accumulated SQL time, and marks repeated statements with their execution count.
+- Optional, extensible collector summaries rendered as headline metrics above a panel. The database collector uses them to report total queries, duplicate runs (executions after the first), and accumulated SQL time, and marks repeated statements with their execution count.
 
 ## [0.4.0](https://github.com/phalcon/debugbar/releases/tag/v0.4.0) (2026-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `phalcon/debugbar` are documented here. The format is based on [Keep a Changelog][keep_a_changelog] and this project adheres to [Semantic Versioning][semantic_versioning].
 
+## Unreleased
+
+### Added
+
+- Optional collector summaries rendered as headline metrics above a panel. The database collector uses them to report total queries, duplicate executions, and accumulated SQL time, and marks statements belonging to a duplicate group.
+
 ## [0.4.0](https://github.com/phalcon/debugbar/releases/tag/v0.4.0) (2026-07-14)
 
 ### Changed

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,7 +102,7 @@ Each collector contributes one tab. A collector reads its data in one of four wa
 |--------------|----------------------------------------------------------|-------------------|
 | `cache`      | Cache operations and their keys                          | streamed          |
 | `config`     | The `config` service, flattened and redacted             | snapshot          |
-| `database`   | SQL statements, bound parameters, and timings            | streamed          |
+| `database`   | SQL statements, bindings, timings, and query summary     | streamed          |
 | `exceptions` | Throwables, with stack traces                            | manual + streamed |
 | `logger`     | Log entries captured from a `Phalcon\Logger` adapter     | adapter           |
 | `messages`   | Messages recorded through the facade                     | manual            |
@@ -241,6 +241,8 @@ use Phalcon\DebugBar\Provider;
 The bar's CSS and JavaScript are minified and injected inline; the bar has no external asset to host or serve. On CSP-restricted pages, set `assets.nonce` so the inline tags carry a nonce.
 
 The bar sits at the bottom of the page. Each collector is a tab; a tab shows a badge when the collector reports a count or a summary value. Clicking a tab opens its panel:
+
+Collectors may expose a summary above their panel. The database collector reports the total query count, duplicate executions, and accumulated SQL time. Duplicate detection groups the same SQL statement after whitespace normalization and deliberately ignores binding values, making repeated prepared statements visible.
 
 - **grid** panels (version, request, config, session, route) render a key and value table.
 - **list** panels (time, messages, database, view, cache) render labelled rows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,7 +242,7 @@ The bar's CSS and JavaScript are minified and injected inline; the bar has no ex
 
 The bar sits at the bottom of the page. Each collector is a tab; a tab shows a badge when the collector reports a count or a summary value. Clicking a tab opens its panel:
 
-Collectors may expose a summary above their panel. The database collector reports the total query count, duplicate executions, and accumulated SQL time. These metrics remain visible with zero values when no queries are executed. Duplicate detection groups the same SQL statement after whitespace normalization and deliberately ignores binding values; repeated statements are highlighted and show how many times they were executed.
+Collectors may expose a summary above their panel. The database collector reports the total query count, duplicate runs, and accumulated SQL time. A duplicate run is each execution of a normalized statement after its first execution: running the same statement three times contributes two duplicate runs. These metrics remain visible with zero values when no queries are executed. Duplicate detection deliberately ignores binding values; repeated statements are highlighted and show their total execution count.
 
 - **grid** panels (version, request, config, session, route) render a key and value table.
 - **list** panels (time, messages, database, view, cache) render labelled rows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,7 +242,7 @@ The bar's CSS and JavaScript are minified and injected inline; the bar has no ex
 
 The bar sits at the bottom of the page. Each collector is a tab; a tab shows a badge when the collector reports a count or a summary value. Clicking a tab opens its panel:
 
-Collectors may expose a summary above their panel. The database collector reports the total query count, duplicate executions, and accumulated SQL time. Duplicate detection groups the same SQL statement after whitespace normalization and deliberately ignores binding values, making repeated prepared statements visible.
+Collectors may expose a summary above their panel. The database collector reports the total query count, duplicate executions, and accumulated SQL time. These metrics remain visible with zero values when no queries are executed. Duplicate detection groups the same SQL statement after whitespace normalization and deliberately ignores binding values; repeated statements are highlighted and show how many times they were executed.
 
 - **grid** panels (version, request, config, session, route) render a key and value table.
 - **list** panels (time, messages, database, view, cache) render labelled rows.

--- a/resources/assets/debugbar.css
+++ b/resources/assets/debugbar.css
@@ -117,6 +117,34 @@
     border-bottom: 1px solid #2b2b40;
 }
 
+#phalcon-debugbar .phalcon-debugbar-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+#phalcon-debugbar .phalcon-debugbar-summary-metric {
+    display: flex;
+    min-width: 130px;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 7px 10px;
+    border: 1px solid #303047;
+    border-radius: 4px;
+    background: #20202e;
+}
+
+#phalcon-debugbar .phalcon-debugbar-summary-label {
+    color: #9a9ac8;
+}
+
+#phalcon-debugbar .phalcon-debugbar-summary-value {
+    color: #ffffff;
+    font-size: 13px;
+}
+
 #phalcon-debugbar table {
     width: 100%;
     border-collapse: collapse;

--- a/resources/assets/debugbar.css
+++ b/resources/assets/debugbar.css
@@ -173,6 +173,22 @@
     color: #e2e2ef;
 }
 
+#phalcon-debugbar .phalcon-debugbar-list tr.is-duplicate {
+    background: #2a2118;
+}
+
+#phalcon-debugbar .phalcon-debugbar-duplicate-count {
+    display: inline-block;
+    margin-left: 10px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: #8a4b08;
+    color: #fff1d6;
+    font-size: 10px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
 #phalcon-debugbar .phalcon-debugbar-code {
     margin: 0;
     white-space: pre-wrap;

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -95,8 +95,23 @@
         panel.forEach(function (row) {
             row = row || {};
             var tr = el('tr');
+            var value = el('td', 'phalcon-debugbar-value');
+            var occurrences = Number(row.occurrences);
+
+            if (occurrences > 1) {
+                tr.classList.add('is-duplicate');
+            }
+
             tr.appendChild(el('td', 'phalcon-debugbar-key', scalar(row.label)));
-            tr.appendChild(el('td', 'phalcon-debugbar-value', scalar(row.message)));
+            value.appendChild(el('span', 'phalcon-debugbar-message', scalar(row.message)));
+            if (occurrences > 1) {
+                value.appendChild(el(
+                    'span',
+                    'phalcon-debugbar-duplicate-count',
+                    'Executed ' + occurrences + ' times'
+                ));
+            }
+            tr.appendChild(value);
             table.appendChild(tr);
         });
         return table;
@@ -176,16 +191,16 @@
     }
 
     function renderSummary(summary) {
-        var keys = summary && typeof summary === 'object' ? Object.keys(summary) : [];
-        if (!keys.length) {
+        if (!Array.isArray(summary) || !summary.length) {
             return null;
         }
 
         var wrap = el('div', 'phalcon-debugbar-summary');
-        keys.forEach(function (label) {
+        summary.forEach(function (item) {
+            item = item || {};
             var metric = el('div', 'phalcon-debugbar-summary-metric');
-            metric.appendChild(el('span', 'phalcon-debugbar-summary-label', label));
-            metric.appendChild(el('strong', 'phalcon-debugbar-summary-value', scalar(summary[label])));
+            metric.appendChild(el('span', 'phalcon-debugbar-summary-label', titleize(item.label)));
+            metric.appendChild(el('strong', 'phalcon-debugbar-summary-value', scalar(item.value)));
             wrap.appendChild(metric);
         });
 

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -175,6 +175,23 @@
         }
     }
 
+    function renderSummary(summary) {
+        var keys = summary && typeof summary === 'object' ? Object.keys(summary) : [];
+        if (!keys.length) {
+            return null;
+        }
+
+        var wrap = el('div', 'phalcon-debugbar-summary');
+        keys.forEach(function (label) {
+            var metric = el('div', 'phalcon-debugbar-summary-metric');
+            metric.appendChild(el('span', 'phalcon-debugbar-summary-label', label));
+            metric.appendChild(el('strong', 'phalcon-debugbar-summary-value', scalar(summary[label])));
+            wrap.appendChild(metric);
+        });
+
+        return wrap;
+    }
+
     function hasBadge(badge) {
         return badge !== null && badge !== undefined && badge !== '' && badge !== 0;
     }
@@ -267,6 +284,10 @@
                 closePanel();
                 tab.classList.add('is-active');
                 body.innerHTML = '';
+                var summary = renderSummary(entry.summary);
+                if (summary) {
+                    body.appendChild(summary);
+                }
                 body.appendChild(renderPanel(type, entry.panel));
                 body.style.display = 'block';
                 active = name;

--- a/src/DebugBar/Collector/DatabaseCollector.php
+++ b/src/DebugBar/Collector/DatabaseCollector.php
@@ -21,6 +21,9 @@ use Phalcon\Events\ManagerInterface;
 
 use function count;
 use function hrtime;
+use function is_string;
+use function preg_replace;
+use function trim;
 
 /**
  * Records SQL queries by subscribing to `db:beforeQuery`/`db:afterQuery`. The
@@ -28,7 +31,7 @@ use function hrtime;
  * read straight off it - no `db` service is resolved.
  *
  * @phpstan-import-type db_query from DebugBarTypes
- * @phpstan-import-type list_envelope from DebugBarTypes
+ * @phpstan-import-type database_envelope from DebugBarTypes
  */
 final class DatabaseCollector extends AbstractCollector implements Subscriber
 {
@@ -63,21 +66,44 @@ final class DatabaseCollector extends AbstractCollector implements Subscriber
     private float | int $started = 0;
 
     /**
-     * @return list_envelope
+     * @return database_envelope
      */
     public function collect(): array
     {
-        $rows = [];
+        $rows              = [];
+        $occurrences       = [];
+        $totalNanoseconds  = 0;
         foreach ($this->queries as $query) {
+            $key               = $this->queryKey($query['sql']);
+            $occurrences[$key] = ($occurrences[$key] ?? 0) + 1;
+            $totalNanoseconds += $query['time'];
+        }
+
+        $duplicates = 0;
+        foreach ($occurrences as $occurrenceCount) {
+            $duplicates += $occurrenceCount - 1;
+        }
+
+        foreach ($this->queries as $query) {
+            $occurrenceCount = $occurrences[$this->queryKey($query['sql'])];
+            $label           = $this->nanosToMs($query['time']);
+            if ($occurrenceCount > 1) {
+                $label .= ' - duplicate x' . $occurrenceCount;
+            }
+
             $rows[] = [
-                'label'   => $this->nanosToMs($query['time']),
+                'label'   => $label,
                 'message' => $this->formatQuery($query['sql'], $query['bindings']),
             ];
         }
-
         return [
-            'panel' => $rows,
-            'badge' => count($this->queries),
+            'panel'   => $rows,
+            'badge'   => count($this->queries),
+            'summary' => [
+                'Queries'     => count($this->queries),
+                'Duplicates' => $duplicates,
+                'Total time'  => $this->nanosToMs($totalNanoseconds),
+            ],
         ];
     }
 
@@ -125,5 +151,15 @@ final class DatabaseCollector extends AbstractCollector implements Subscriber
         }
 
         return $sql . '  ' . $this->jsonOrEmpty($bindings);
+    }
+
+    /**
+     * Binding values are deliberately excluded: repeated executions of one
+     * prepared statement are the duplication pattern this metric exposes.
+     */
+    private function queryKey(string $sql): string
+    {
+        $normalized = preg_replace('/\s+/', ' ', trim($sql));
+        return is_string($normalized) ? $normalized : trim($sql);
     }
 }

--- a/src/DebugBar/Collector/DatabaseCollector.php
+++ b/src/DebugBar/Collector/DatabaseCollector.php
@@ -73,14 +73,14 @@ final class DatabaseCollector extends AbstractCollector implements Subscriber
         $rows              = [];
         $occurrences       = [];
         $queryKeys         = [];
-        $duplicates        = 0;
+        $duplicateRuns     = 0;
         $totalNanoseconds  = 0;
-        foreach ($this->queries as $query) {
+        foreach ($this->queries as $index => $query) {
             $key               = $this->queryKey($query['sql']);
-            $queryKeys[]       = $key;
+            $queryKeys[$index] = $key;
             $occurrences[$key] = ($occurrences[$key] ?? 0) + 1;
             if ($occurrences[$key] > 1) {
-                $duplicates++;
+                $duplicateRuns++;
             }
             $totalNanoseconds += $query['time'];
         }
@@ -99,7 +99,7 @@ final class DatabaseCollector extends AbstractCollector implements Subscriber
             'badge'   => count($this->queries),
             'summary' => [
                 ['label' => 'queries', 'value' => count($this->queries)],
-                ['label' => 'duplicates', 'value' => $duplicates],
+                ['label' => 'duplicate_runs', 'value' => $duplicateRuns],
                 ['label' => 'total_time', 'value' => $this->nanosToMs($totalNanoseconds)],
             ],
         ];

--- a/src/DebugBar/Collector/DatabaseCollector.php
+++ b/src/DebugBar/Collector/DatabaseCollector.php
@@ -72,37 +72,35 @@ final class DatabaseCollector extends AbstractCollector implements Subscriber
     {
         $rows              = [];
         $occurrences       = [];
+        $queryKeys         = [];
+        $duplicates        = 0;
         $totalNanoseconds  = 0;
         foreach ($this->queries as $query) {
             $key               = $this->queryKey($query['sql']);
+            $queryKeys[]       = $key;
             $occurrences[$key] = ($occurrences[$key] ?? 0) + 1;
+            if ($occurrences[$key] > 1) {
+                $duplicates++;
+            }
             $totalNanoseconds += $query['time'];
         }
 
-        $duplicates = 0;
-        foreach ($occurrences as $occurrenceCount) {
-            $duplicates += $occurrenceCount - 1;
-        }
-
-        foreach ($this->queries as $query) {
-            $occurrenceCount = $occurrences[$this->queryKey($query['sql'])];
-            $label           = $this->nanosToMs($query['time']);
-            if ($occurrenceCount > 1) {
-                $label .= ' - duplicate x' . $occurrenceCount;
-            }
-
+        foreach ($this->queries as $index => $query) {
+            $occurrenceCount = $occurrences[$queryKeys[$index]];
             $rows[] = [
-                'label'   => $label,
-                'message' => $this->formatQuery($query['sql'], $query['bindings']),
+                'label'       => $this->nanosToMs($query['time']),
+                'message'     => $this->formatQuery($query['sql'], $query['bindings']),
+                'occurrences' => $occurrenceCount > 1 ? $occurrenceCount : null,
             ];
         }
+
         return [
             'panel'   => $rows,
             'badge'   => count($this->queries),
             'summary' => [
-                'Queries'     => count($this->queries),
-                'Duplicates' => $duplicates,
-                'Total time'  => $this->nanosToMs($totalNanoseconds),
+                ['label' => 'queries', 'value' => count($this->queries)],
+                ['label' => 'duplicates', 'value' => $duplicates],
+                ['label' => 'total_time', 'value' => $this->nanosToMs($totalNanoseconds)],
             ],
         ];
     }

--- a/src/DebugBar/Contracts/Collector.php
+++ b/src/DebugBar/Contracts/Collector.php
@@ -18,7 +18,8 @@ use Phalcon\DebugBar\DebugBarTypes;
 /**
  * The data contract every collector implements. `collect()` returns an
  * envelope: `panel` holds the data shaped for the declared panel renderer,
- * `badge` is the optional scalar tab count.
+ * `badge` is the optional scalar tab count, and `summary` is an optional map
+ * of headline metrics rendered above the panel.
  *
  * @phpstan-import-type envelope from DebugBarTypes
  */

--- a/src/DebugBar/Contracts/Collector.php
+++ b/src/DebugBar/Contracts/Collector.php
@@ -18,8 +18,8 @@ use Phalcon\DebugBar\DebugBarTypes;
 /**
  * The data contract every collector implements. `collect()` returns an
  * envelope: `panel` holds the data shaped for the declared panel renderer,
- * `badge` is the optional scalar tab count, and `summary` is an optional map
- * of headline metrics rendered above the panel.
+ * `badge` is the optional scalar tab count, and `summary` is an optional list
+ * of label/value metrics rendered above the panel.
  *
  * @phpstan-import-type envelope from DebugBarTypes
  */

--- a/src/DebugBar/DebugBarTypes.php
+++ b/src/DebugBar/DebugBarTypes.php
@@ -25,13 +25,16 @@ namespace Phalcon\DebugBar;
  * @phpstan-type log_row array{label: string, message: string, context: string}
  * @phpstan-type log_panel list<log_row>
  * @phpstan-type widget array{label: string, icon: string, panel: string}
- * @phpstan-type envelope array{panel: mixed, badge: scalar|null}
- * @phpstan-type list_envelope array{panel: list_panel, badge: scalar|null}
- * @phpstan-type grid_envelope array{panel: grid_panel, badge: scalar|null}
- * @phpstan-type exception_envelope array{panel: exception_panel, badge: scalar|null}
- * @phpstan-type log_envelope array{panel: log_panel, badge: scalar|null}
+ * @phpstan-type collector_summary array<string, scalar>
+ * @phpstan-type envelope array{panel: mixed, badge: scalar|null, summary?: collector_summary}
+ * @phpstan-type list_envelope array{panel: list_panel, badge: scalar|null, summary?: collector_summary}
+ * @phpstan-type grid_envelope array{panel: grid_panel, badge: scalar|null, summary?: collector_summary}
+ * @phpstan-type exception_envelope array{panel: exception_panel, badge: scalar|null, summary?: collector_summary}
+ * @phpstan-type log_envelope array{panel: log_panel, badge: scalar|null, summary?: collector_summary}
  * @phpstan-type payload array{data: array<string, envelope>, meta: array<string, mixed>}
  * @phpstan-type db_query array{sql: string, bindings: array<array-key, mixed>, time: int|float}
+ * @phpstan-type database_summary array{Queries: int, Duplicates: int, 'Total time': string}
+ * @phpstan-type database_envelope array{panel: list_panel, badge: int, summary: database_summary}
  * @phpstan-type time_measure array{label: string, start: int|float, end: int|float|null}
  * @phpstan-type view_pending array{path: string, start: int|float}
  * @phpstan-type view_render array{path: string, time: int|float}

--- a/src/DebugBar/DebugBarTypes.php
+++ b/src/DebugBar/DebugBarTypes.php
@@ -25,7 +25,8 @@ namespace Phalcon\DebugBar;
  * @phpstan-type log_row array{label: string, message: string, context: string}
  * @phpstan-type log_panel list<log_row>
  * @phpstan-type widget array{label: string, icon: string, panel: string}
- * @phpstan-type collector_summary array<string, scalar>
+ * @phpstan-type summary_row array{label: string, value: scalar}
+ * @phpstan-type collector_summary list<summary_row>
  * @phpstan-type envelope array{panel: mixed, badge: scalar|null, summary?: collector_summary}
  * @phpstan-type list_envelope array{panel: list_panel, badge: scalar|null, summary?: collector_summary}
  * @phpstan-type grid_envelope array{panel: grid_panel, badge: scalar|null, summary?: collector_summary}
@@ -33,8 +34,9 @@ namespace Phalcon\DebugBar;
  * @phpstan-type log_envelope array{panel: log_panel, badge: scalar|null, summary?: collector_summary}
  * @phpstan-type payload array{data: array<string, envelope>, meta: array<string, mixed>}
  * @phpstan-type db_query array{sql: string, bindings: array<array-key, mixed>, time: int|float}
- * @phpstan-type database_summary array{Queries: int, Duplicates: int, 'Total time': string}
- * @phpstan-type database_envelope array{panel: list_panel, badge: int, summary: database_summary}
+ * @phpstan-type database_row array{label: string, message: string, occurrences: int|null}
+ * @phpstan-type database_panel list<database_row>
+ * @phpstan-type database_envelope array{panel: database_panel, badge: int, summary: collector_summary}
  * @phpstan-type time_measure array{label: string, start: int|float, end: int|float|null}
  * @phpstan-type view_pending array{path: string, start: int|float}
  * @phpstan-type view_render array{path: string, time: int|float}

--- a/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
+++ b/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
@@ -49,18 +49,34 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
     public function testDuplicateDetectionIgnoresBindingsButNotDifferentStatements(): void
     {
         $collector = new DatabaseCollector();
-        $property = new ReflectionProperty(DatabaseCollector::class, 'queries');
-        $property->setValue($collector, [
+        $property  = new ReflectionProperty(DatabaseCollector::class, 'queries');
+        $property->setAccessible(true);
+        $property->setValue(
+            $collector,
+            [
                 ['sql' => 'SELECT * FROM users WHERE id = :id', 'bindings' => ['id' => 1], 'time' => 100000],
                 ['sql' => 'SELECT * FROM users WHERE id = :id', 'bindings' => ['id' => 2], 'time' => 200000],
+                ['sql' => 'SELECT * FROM users WHERE id = :id', 'bindings' => ['id' => 3], 'time' => 300000],
                 [
                     'sql'      => 'SELECT * FROM users WHERE email = :email',
                     'bindings' => ['email' => 'a@b.c'],
-                    'time'     => 300000,
+                    'time'     => 400000,
                 ],
-            ]);
+                ['sql' => 'SELECT * FROM roles', 'bindings' => [], 'time' => 500000],
+            ]
+        );
+
         $envelope = $collector->collect();
-        $this->assertSame(1, $envelope['summary']['Duplicates']);
+
+        $this->assertSame(
+            [
+                ['label' => 'queries', 'value' => 5],
+                ['label' => 'duplicates', 'value' => 2],
+                ['label' => 'total_time', 'value' => '1.5ms'],
+            ],
+            $envelope['summary']
+        );
+        $this->assertSame([3, 3, 3, null, null], array_column($envelope['panel'], 'occurrences'));
     }
 
     public function testDurationIsMeasuredBetweenBeforeAndAfterQuery(): void
@@ -96,7 +112,14 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
     public function testEmptyCollectorHasZeroSummaryValues(): void
     {
         $envelope = (new DatabaseCollector())->collect();
-        $this->assertSame(['Queries' => 0, 'Duplicates' => 0, 'Total time' => '0ms'], $envelope['summary']);
+        $this->assertSame(
+            [
+                ['label' => 'queries', 'value' => 0],
+                ['label' => 'duplicates', 'value' => 0],
+                ['label' => 'total_time', 'value' => '0ms'],
+            ],
+            $envelope['summary']
+        );
     }
 
     public function testLabelReflectsQueryDurationInMilliseconds(): void
@@ -118,8 +141,10 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertArrayHasKey('label', $row);
         $this->assertSame('3.46ms', $row['label']);
         $this->assertSame('SELECT 1', $row['message']);
+        $this->assertNull($row['occurrences']);
         $this->assertSame(1, $envelope['badge']);
     }
+
     public function testNameAndPanelContract(): void
     {
         $collector = new DatabaseCollector();
@@ -161,8 +186,11 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
     public function testSummaryReportsQueryCountDuplicatesAndTotalDuration(): void
     {
         $collector = new DatabaseCollector();
-        $property = new ReflectionProperty(DatabaseCollector::class, 'queries');
-        $property->setValue($collector, [
+        $property  = new ReflectionProperty(DatabaseCollector::class, 'queries');
+        $property->setAccessible(true);
+        $property->setValue(
+            $collector,
+            [
                 [
                     'sql'      => 'SELECT * FROM users WHERE id = :id',
                     'bindings' => ['id' => 1],
@@ -178,15 +206,32 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
                     'bindings' => [],
                     'time'     => 500000,
                 ],
-            ]);
+            ]
+        );
+
         $envelope = $collector->collect();
-        $this->assertSame([
-                'Queries'     => 3,
-                'Duplicates' => 1,
-                'Total time'  => '3.75ms',
-            ], $envelope['summary']);
-        $this->assertStringContainsString('duplicate x2', $envelope['panel'][0]['label']);
-        $this->assertStringContainsString('duplicate x2', $envelope['panel'][1]['label']);
-        $this->assertStringNotContainsString('duplicate', $envelope['panel'][2]['label']);
+
+        $this->assertSame(
+            [
+                ['label' => 'queries', 'value' => 3],
+                ['label' => 'duplicates', 'value' => 1],
+                ['label' => 'total_time', 'value' => '3.75ms'],
+            ],
+            $envelope['summary']
+        );
+        $this->assertSame(
+            [
+                ['label' => '1.25ms', 'occurrences' => 2],
+                ['label' => '2ms', 'occurrences' => 2],
+                ['label' => '0.5ms', 'occurrences' => null],
+            ],
+            array_map(
+                static fn (array $row): array => [
+                    'label'       => $row['label'],
+                    'occurrences' => $row['occurrences'],
+                ],
+                $envelope['panel']
+            )
+        );
     }
 }

--- a/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
+++ b/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
@@ -46,6 +46,23 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         );
     }
 
+    public function testDuplicateDetectionIgnoresBindingsButNotDifferentStatements(): void
+    {
+        $collector = new DatabaseCollector();
+        $property = new ReflectionProperty(DatabaseCollector::class, 'queries');
+        $property->setValue($collector, [
+                ['sql' => 'SELECT * FROM users WHERE id = :id', 'bindings' => ['id' => 1], 'time' => 100000],
+                ['sql' => 'SELECT * FROM users WHERE id = :id', 'bindings' => ['id' => 2], 'time' => 200000],
+                [
+                    'sql'      => 'SELECT * FROM users WHERE email = :email',
+                    'bindings' => ['email' => 'a@b.c'],
+                    'time'     => 300000,
+                ],
+            ]);
+        $envelope = $collector->collect();
+        $this->assertSame(1, $envelope['summary']['Duplicates']);
+    }
+
     public function testDurationIsMeasuredBetweenBeforeAndAfterQuery(): void
     {
         $collector     = new DatabaseCollector();
@@ -76,6 +93,12 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertLessThan(1000000000, $time);
     }
 
+    public function testEmptyCollectorHasZeroSummaryValues(): void
+    {
+        $envelope = (new DatabaseCollector())->collect();
+        $this->assertSame(['Queries' => 0, 'Duplicates' => 0, 'Total time' => '0ms'], $envelope['summary']);
+    }
+
     public function testLabelReflectsQueryDurationInMilliseconds(): void
     {
         $collector = new DatabaseCollector();
@@ -97,7 +120,6 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertSame('SELECT 1', $row['message']);
         $this->assertSame(1, $envelope['badge']);
     }
-
     public function testNameAndPanelContract(): void
     {
         $collector = new DatabaseCollector();
@@ -134,5 +156,37 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
 
         $this->assertSame(1, $envelope['badge']);
         $this->assertSame('SELECT 1', $envelope['panel'][0]['message']);
+    }
+
+    public function testSummaryReportsQueryCountDuplicatesAndTotalDuration(): void
+    {
+        $collector = new DatabaseCollector();
+        $property = new ReflectionProperty(DatabaseCollector::class, 'queries');
+        $property->setValue($collector, [
+                [
+                    'sql'      => 'SELECT * FROM users WHERE id = :id',
+                    'bindings' => ['id' => 1],
+                    'time'     => 1250000,
+                ],
+                [
+                    'sql'      => " SELECT  *  FROM users WHERE id = :id ",
+                    'bindings' => ['id' => 2],
+                    'time'     => 2000000,
+                ],
+                [
+                    'sql'      => 'SELECT * FROM roles',
+                    'bindings' => [],
+                    'time'     => 500000,
+                ],
+            ]);
+        $envelope = $collector->collect();
+        $this->assertSame([
+                'Queries'     => 3,
+                'Duplicates' => 1,
+                'Total time'  => '3.75ms',
+            ], $envelope['summary']);
+        $this->assertStringContainsString('duplicate x2', $envelope['panel'][0]['label']);
+        $this->assertStringContainsString('duplicate x2', $envelope['panel'][1]['label']);
+        $this->assertStringNotContainsString('duplicate', $envelope['panel'][2]['label']);
     }
 }

--- a/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
+++ b/tests/Unit/DebugBar/Collector/DatabaseCollectorTest.php
@@ -71,7 +71,7 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertSame(
             [
                 ['label' => 'queries', 'value' => 5],
-                ['label' => 'duplicates', 'value' => 2],
+                ['label' => 'duplicate_runs', 'value' => 2],
                 ['label' => 'total_time', 'value' => '1.5ms'],
             ],
             $envelope['summary']
@@ -115,7 +115,7 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertSame(
             [
                 ['label' => 'queries', 'value' => 0],
-                ['label' => 'duplicates', 'value' => 0],
+                ['label' => 'duplicate_runs', 'value' => 0],
                 ['label' => 'total_time', 'value' => '0ms'],
             ],
             $envelope['summary']
@@ -214,7 +214,7 @@ final class DatabaseCollectorTest extends AbstractUnitTestCase
         $this->assertSame(
             [
                 ['label' => 'queries', 'value' => 3],
-                ['label' => 'duplicates', 'value' => 1],
+                ['label' => 'duplicate_runs', 'value' => 1],
                 ['label' => 'total_time', 'value' => '3.75ms'],
             ],
             $envelope['summary']

--- a/tests/Unit/DebugBar/RendererTest.php
+++ b/tests/Unit/DebugBar/RendererTest.php
@@ -104,6 +104,13 @@ final class RendererTest extends AbstractUnitTestCase
         $this->assertStringContainsString('>{}</script>', $html);
     }
 
+    public function testRenderHeadIncludesCollectorSummaryAssets(): void
+    {
+        $html = (new Renderer())->renderHead();
+        $this->assertStringContainsString('phalcon-debugbar-summary', $html);
+        $this->assertStringContainsString('entry.summary', $html);
+    }
+
     public function testRenderHeadInlinesMinifiedAssets(): void
     {
         $html = (new Renderer())->renderHead();
@@ -113,7 +120,6 @@ final class RendererTest extends AbstractUnitTestCase
         $this->assertStringContainsString('<script', $html);
         $this->assertStringContainsString('phalcon-debugbar-data', $html);
     }
-
     public function testRenderHeadUsesCssMinifierForStyles(): void
     {
         // The CSS minifier shortens #ffffff to #fff; running the JS minifier on

--- a/tests/Unit/DebugBar/RendererTest.php
+++ b/tests/Unit/DebugBar/RendererTest.php
@@ -109,6 +109,8 @@ final class RendererTest extends AbstractUnitTestCase
         $html = (new Renderer())->renderHead();
         $this->assertStringContainsString('phalcon-debugbar-summary', $html);
         $this->assertStringContainsString('entry.summary', $html);
+        $this->assertStringContainsString('is-duplicate', $html);
+        $this->assertStringContainsString('Executed ', $html);
     }
 
     public function testRenderHeadInlinesMinifiedAssets(): void

--- a/tests/support/DebugBar/PanelContractTrait.php
+++ b/tests/support/DebugBar/PanelContractTrait.php
@@ -30,9 +30,13 @@ trait PanelContractTrait
         $data      = $collected['panel'];
         if (isset($collected['summary'])) {
             Assert::assertIsArray($collected['summary']);
-            foreach ($collected['summary'] as $label => $value) {
-                Assert::assertIsString($label);
-                Assert::assertIsScalar($value);
+            Assert::assertIsList($collected['summary']);
+            foreach ($collected['summary'] as $metric) {
+                Assert::assertIsArray($metric);
+                Assert::assertArrayHasKey('label', $metric);
+                Assert::assertArrayHasKey('value', $metric);
+                Assert::assertIsString($metric['label']);
+                Assert::assertIsScalar($metric['value']);
             }
         }
         switch ($panel) {

--- a/tests/support/DebugBar/PanelContractTrait.php
+++ b/tests/support/DebugBar/PanelContractTrait.php
@@ -25,9 +25,16 @@ trait PanelContractTrait
 {
     protected function assertPanelContract(Renderable $collector): void
     {
-        $panel = $collector->getWidget()['panel'];
-        $data  = $collector->collect()['panel'];
-
+        $panel     = $collector->getWidget()['panel'];
+        $collected = $collector->collect();
+        $data      = $collected['panel'];
+        if (isset($collected['summary'])) {
+            Assert::assertIsArray($collected['summary']);
+            foreach ($collected['summary'] as $label => $value) {
+                Assert::assertIsString($label);
+                Assert::assertIsScalar($value);
+            }
+        }
         switch ($panel) {
             case 'grid':
                 Assert::assertIsArray($data);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: N/A

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/debugbar/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] Documentation for this change is included in this PR

Small description of change:

Adds a structured summary to the Database panel with:

- total query count;
- duplicate runs, defined as executions of a normalized statement after its first execution;
- accumulated SQL execution time.

For example, executing the same normalized statement three times contributes two duplicate runs. Statement normalization collapses whitespace and deliberately ignores binding values, so repeated executions of one prepared statement are grouped together.

Each repeated row exposes its total `occurrences` as structured data. The frontend uses that value to apply a duplicate-row CSS class and display `Executed N times` without changing the duration label. The summary remains visible with zero values when no queries are executed.

The collector and renderer tests cover repeated statements with different bindings, unique statements, per-row occurrence counts, summary values, and the zero-query state. The behavior is also documented in `docs/index.md`.

Thanks
