### PR TITLE
Add session-scoped request history browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to `phalcon/debugbar` are documented here. The format is bas
 ### Added
 
 - Optional, session-isolated request history with filesystem retention, an
-  internal `GET /_debugbar/open` controller, and an inline request browser that
-  swaps the bar payload without leaving the current page.
+  internal `GET/DELETE /_debugbar/open` controller, and a collapsible request
+  browser with refresh and clear controls that swaps the bar payload without
+  leaving the current page.
 
 ## [0.4.0](https://github.com/phalcon/debugbar/releases/tag/v0.4.0) (2026-07-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `phalcon/debugbar` are documented here. The format is based on [Keep a Changelog][keep_a_changelog] and this project adheres to [Semantic Versioning][semantic_versioning].
 
+## Unreleased
+
+### Added
+
+- Optional, session-isolated request history with filesystem retention, an
+  internal `GET /_debugbar/open` controller, and an inline request browser that
+  swaps the bar payload without leaving the current page.
+
 ## [0.4.0](https://github.com/phalcon/debugbar/releases/tag/v0.4.0) (2026-07-14)
 
 ### Changed

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ The remainder of this document covers the debug bar.
 
 ## Registering the Debug Bar
 
-The bar is booted by `Phalcon\DebugBar\Provider`. It takes the MVC application and an optional configuration array. Its only coupling to the application is the application's events manager, so the application must have one set before the bar boots.
+The bar is booted by `Phalcon\DebugBar\Provider`. It takes the MVC application and an optional configuration array. The application must have an events manager set before the bar boots. Request history additionally requires the application's shared `router`, `request`, and `response` services.
 
 ```php
 <?php
@@ -73,6 +73,11 @@ The second argument to `Provider` is a nested array. Every key is optional.
 | `env.strict`       | `bool`                    | `false`                  | When `true`, `boot()` throws in a blocked/undefined environment instead of returning silently. |
 | `env.var`          | `string`                  | `APP_ENV`                | Environment variable inspected by the gate.                      |
 | `headers`          | `bool`                    | `true`                   | Emit the `X-Debug-Bar` diagnostic header.                        |
+| `history.enabled`  | `bool`                    | `false`                  | Store and browse recent requests for the active session.         |
+| `history.url`      | `string`                  | `/_debugbar/open`        | Internal GET endpoint registered by the provider.                |
+| `history.path`     | `string`                  | system temporary path    | Storage directory; keep it outside the document root.            |
+| `history.max_requests` | `int`                 | `100`                    | Maximum stored requests per session.                             |
+| `history.ttl_seconds` | `int`                  | `86400`                  | Lifetime of stored requests in seconds.                          |
 | `redact.hidden`    | `list<string>`            | `[]`                     | Keys dropped from the output entirely.                           |
 | `redact.mask`      | `list<string>`            | `[]`                     | Extra keys whose values are masked (added to the defaults).      |
 
@@ -85,9 +90,22 @@ use Phalcon\DebugBar\Provider;
     'env'        => ['var' => 'APP_ENV', 'blocked' => ['production', 'staging']],
     'access'     => ['allow_ips' => ['127.0.0.1', '10.0.0.5']],
     'collectors' => ['cache' => false, 'view' => false],
+    'history'    => [
+        'enabled'      => true,
+        'path'         => dirname(__DIR__) . '/runtime/debugbar',
+        'max_requests' => 100,
+        'ttl_seconds'  => 86400,
+    ],
     'redact'     => ['mask' => ['api_key'], 'hidden' => ['secret_question']],
 ]))->boot();
 ```
+
+When history is enabled, the provider registers `GET /_debugbar/open` and its
+internal controller automatically. A request without an `id` returns the recent
+request metadata; `?id=<request-id>` returns a stored payload. The browser is
+rendered directly above the bar and selecting an item replaces the collectors
+shown below it. Storage is isolated by a SHA-256 hash of the active PHP session
+id. With no active session, no request is written or exposed.
 
 ## Collectors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,12 +100,14 @@ use Phalcon\DebugBar\Provider;
 ]))->boot();
 ```
 
-When history is enabled, the provider registers `GET /_debugbar/open` and its
-internal controller automatically. A request without an `id` returns the recent
-request metadata; `?id=<request-id>` returns a stored payload. The browser is
-rendered directly above the bar and selecting an item replaces the collectors
-shown below it. Storage is isolated by a SHA-256 hash of the active PHP session
-id. With no active session, no request is written or exposed.
+When history is enabled, the provider registers `GET /_debugbar/open`,
+`DELETE /_debugbar/open`, and their internal controller automatically. A GET
+without an `id` returns the recent request metadata; `?id=<request-id>` returns
+a stored payload. DELETE clears the active session's stored requests. The
+`History` item in the bottom bar opens the browser above it; its controls refresh
+or clear the list, and selecting an item replaces the collectors shown below.
+Storage is isolated by a SHA-256 hash of the active PHP session id. With no
+active session, no request is written or exposed.
 
 ## Collectors
 

--- a/resources/assets/debugbar.css
+++ b/resources/assets/debugbar.css
@@ -120,10 +120,62 @@
 
 #phalcon-debugbar .phalcon-debugbar-history-browser {
     display: none;
-    max-height: 156px;
+    max-height: 210px;
     overflow: auto;
     background: #101018;
     border-bottom: 1px solid #2b2b40;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 14px;
+    background: #181824;
+    border-bottom: 1px solid #2b2b40;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-title {
+    color: #d5d5e8;
+    font-size: 12px;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-actions {
+    display: flex;
+    gap: 6px;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-action {
+    padding: 3px 9px;
+    border: 1px solid #454563;
+    border-radius: 3px;
+    background: #29293d;
+    color: #d5d5e8;
+    font: inherit;
+    cursor: pointer;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-action:hover {
+    background: #353550;
+    color: #ffffff;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-action.is-danger {
+    border-color: #7f3445;
+    color: #ff9aac;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-action.is-danger:hover {
+    background: #542532;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-action:disabled {
+    opacity: 0.5;
+    cursor: default;
 }
 
 #phalcon-debugbar .phalcon-debugbar-history-list {

--- a/resources/assets/debugbar.css
+++ b/resources/assets/debugbar.css
@@ -28,6 +28,7 @@
 }
 
 #phalcon-debugbar.is-collapsed .phalcon-debugbar-body,
+#phalcon-debugbar.is-collapsed .phalcon-debugbar-history-browser,
 #phalcon-debugbar.is-collapsed .phalcon-debugbar-tabs {
     display: none;
 }
@@ -115,6 +116,81 @@
     padding: 10px 14px;
     background: #14141d;
     border-bottom: 1px solid #2b2b40;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-browser {
+    display: none;
+    max-height: 156px;
+    overflow: auto;
+    background: #101018;
+    border-bottom: 1px solid #2b2b40;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-list {
+    display: flex;
+    flex-direction: column;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-request {
+    display: grid;
+    grid-template-columns: 58px minmax(180px, 1fr) 48px 210px;
+    gap: 10px;
+    align-items: center;
+    padding: 5px 14px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid #232334;
+    color: #b9b9d4;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-request:hover,
+#phalcon-debugbar .phalcon-debugbar-history-request.is-selected {
+    background: #26263a;
+    color: #ffffff;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-request.is-selected {
+    box-shadow: inset 3px 0 #7c3aed;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-method {
+    color: #a78bfa;
+    font-weight: 700;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-uri {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-status,
+#phalcon-debugbar .phalcon-debugbar-history-time {
+    color: #8f8faa;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-loading,
+#phalcon-debugbar .phalcon-debugbar-history-empty,
+#phalcon-debugbar .phalcon-debugbar-history-error {
+    padding: 8px 14px;
+    color: #8f8faa;
+}
+
+#phalcon-debugbar .phalcon-debugbar-history-error {
+    color: #ff6b81;
+}
+
+@media (max-width: 760px) {
+    #phalcon-debugbar .phalcon-debugbar-history-request {
+        grid-template-columns: 52px minmax(120px, 1fr) 42px;
+    }
+
+    #phalcon-debugbar .phalcon-debugbar-history-time {
+        display: none;
+    }
 }
 
 #phalcon-debugbar table {

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -187,11 +187,13 @@
         return url + (url.indexOf('?') === -1 ? '?' : '&') + 'id=' + encodeURIComponent(id);
     }
 
-    function loadJson(url) {
-        return window.fetch(url, {
-            credentials: 'same-origin',
-            headers: {'Accept': 'application/json'}
-        }).then(function (response) {
+    function requestJson(url, options) {
+        options = options || {};
+        options.credentials = 'same-origin';
+        options.headers = options.headers || {};
+        options.headers.Accept = 'application/json';
+
+        return window.fetch(url, options).then(function (response) {
             if (!response.ok) {
                 throw new Error('HTTP ' + response.status);
             }
@@ -200,7 +202,11 @@
         });
     }
 
-    function renderHistoryBrowser(mount, panel, selectedId, onSelect) {
+    function loadJson(url) {
+        return requestJson(url, {});
+    }
+
+    function renderHistoryBrowser(mount, panel, selectedId, onSelect, onClear) {
         mount.innerHTML = '';
 
         var url = panel && typeof panel.url === 'string' ? panel.url : '';
@@ -210,53 +216,96 @@
         }
 
         mount.style.display = 'block';
-        mount.appendChild(el('div', 'phalcon-debugbar-history-loading', 'Loading request history...'));
+        var toolbar = el('div', 'phalcon-debugbar-history-toolbar');
+        var title = el('strong', 'phalcon-debugbar-history-title', 'Request history');
+        var actions = el('div', 'phalcon-debugbar-history-actions');
+        var refreshButton = el('button', 'phalcon-debugbar-history-action', 'Refresh');
+        var clearButton = el('button', 'phalcon-debugbar-history-action is-danger', 'Clear');
+        var content = el('div', 'phalcon-debugbar-history-content');
+        refreshButton.type = 'button';
+        clearButton.type = 'button';
+        actions.appendChild(refreshButton);
+        actions.appendChild(clearButton);
+        toolbar.appendChild(title);
+        toolbar.appendChild(actions);
+        mount.appendChild(toolbar);
+        mount.appendChild(content);
 
-        loadJson(url).then(function (result) {
-            mount.innerHTML = '';
-            var requests = result && Array.isArray(result.requests) ? result.requests : [];
-            if (!requests.length) {
-                mount.appendChild(el('div', 'phalcon-debugbar-history-empty', 'No stored requests'));
+        function message(className, text) {
+            content.innerHTML = '';
+            content.appendChild(el('div', className, text));
+        }
+
+        function refresh() {
+            refreshButton.disabled = true;
+            message('phalcon-debugbar-history-loading', 'Loading request history...');
+
+            loadJson(url).then(function (result) {
+                content.innerHTML = '';
+                var requests = result && Array.isArray(result.requests) ? result.requests : [];
+                clearButton.disabled = !requests.length;
+                if (!requests.length) {
+                    content.appendChild(el('div', 'phalcon-debugbar-history-empty', 'No stored requests'));
+                    return;
+                }
+
+                var list = el('div', 'phalcon-debugbar-history-list');
+                requests.forEach(function (request) {
+                    request = request || {};
+                    var id = scalar(request.id);
+                    var button = el('button', 'phalcon-debugbar-history-request');
+                    button.type = 'button';
+                    if (id === selectedId) {
+                        button.classList.add('is-selected');
+                    }
+
+                    button.appendChild(el(
+                        'span',
+                        'phalcon-debugbar-history-method method-' + scalar(request.method).toLowerCase(),
+                        scalar(request.method)
+                    ));
+                    button.appendChild(el('span', 'phalcon-debugbar-history-uri', scalar(request.uri)));
+                    button.appendChild(el('span', 'phalcon-debugbar-history-status', scalar(request.status)));
+                    button.appendChild(el('time', 'phalcon-debugbar-history-time', scalar(request.requested_at)));
+
+                    button.addEventListener('click', function () {
+                        button.disabled = true;
+                        loadJson(historyUrl(url, id)).then(function (detail) {
+                            if (detail && detail.request && detail.request.payload) {
+                                onSelect(detail.request.payload, id);
+                            }
+                        }).catch(function () {
+                            button.disabled = false;
+                        });
+                    });
+
+                    list.appendChild(button);
+                });
+                content.appendChild(list);
+            }).catch(function () {
+                message('phalcon-debugbar-history-error', 'Unable to load request history');
+            }).then(function () {
+                refreshButton.disabled = false;
+            });
+        }
+
+        refreshButton.addEventListener('click', refresh);
+        clearButton.addEventListener('click', function () {
+            if (!window.confirm('Clear request history?')) {
                 return;
             }
 
-            var list = el('div', 'phalcon-debugbar-history-list');
-            requests.forEach(function (request) {
-                request = request || {};
-                var id = scalar(request.id);
-                var button = el('button', 'phalcon-debugbar-history-request');
-                button.type = 'button';
-                if (id === selectedId) {
-                    button.classList.add('is-selected');
-                }
-
-                button.appendChild(el(
-                    'span',
-                    'phalcon-debugbar-history-method method-' + scalar(request.method).toLowerCase(),
-                    scalar(request.method)
-                ));
-                button.appendChild(el('span', 'phalcon-debugbar-history-uri', scalar(request.uri)));
-                button.appendChild(el('span', 'phalcon-debugbar-history-status', scalar(request.status)));
-                button.appendChild(el('time', 'phalcon-debugbar-history-time', scalar(request.requested_at)));
-
-                button.addEventListener('click', function () {
-                    button.disabled = true;
-                    loadJson(historyUrl(url, id)).then(function (detail) {
-                        if (detail && detail.request && detail.request.payload) {
-                            onSelect(detail.request.payload, id);
-                        }
-                    }).catch(function () {
-                        button.disabled = false;
-                    });
-                });
-
-                list.appendChild(button);
+            clearButton.disabled = true;
+            requestJson(url, {method: 'DELETE'}).then(function () {
+                onClear();
+                refresh();
+            }).catch(function () {
+                clearButton.disabled = false;
+                message('phalcon-debugbar-history-error', 'Unable to clear request history');
             });
-            mount.appendChild(list);
-        }).catch(function () {
-            mount.innerHTML = '';
-            mount.appendChild(el('div', 'phalcon-debugbar-history-error', 'Unable to load request history'));
         });
+
+        refresh();
     }
 
     function readCollapsed() {
@@ -304,18 +353,51 @@
 
         var active = null;
         var selectedHistoryId = '';
+        var historyOpen = false;
+        var historyPanel = null;
+        var historyTab = null;
 
         function closePanel() {
             body.style.display = 'none';
             active = null;
-            Array.prototype.forEach.call(tabs.children, function (child) {
+            Array.prototype.forEach.call(tabs.querySelectorAll('[data-panel-tab]'), function (child) {
                 child.classList.remove('is-active');
             });
+        }
+
+        function renderOpenHistory() {
+            if (!historyOpen || !historyPanel) {
+                historyBrowser.style.display = 'none';
+                return;
+            }
+
+            renderHistoryBrowser(
+                historyBrowser,
+                historyPanel,
+                selectedHistoryId,
+                function (storedPayload, id) {
+                    var activeBeforeSelection = active;
+                    selectedHistoryId = id;
+                    renderData(storedPayload, activeBeforeSelection);
+                },
+                function () {
+                    selectedHistoryId = '';
+                }
+            );
+        }
+
+        function setHistoryOpen(open) {
+            historyOpen = Boolean(open && historyPanel);
+            if (historyTab) {
+                historyTab.classList.toggle('is-active', historyOpen);
+            }
+            renderOpenHistory();
         }
 
         function setCollapsed(collapsed) {
             if (collapsed) {
                 closePanel();
+                setHistoryOpen(false);
                 mount.classList.add('is-collapsed');
             } else {
                 mount.classList.remove('is-collapsed');
@@ -358,6 +440,7 @@
 
                 var tab = el('button', 'phalcon-debugbar-tab');
                 tab.type = 'button';
+                tab.setAttribute('data-panel-tab', name);
                 tab.appendChild(el('span', 'phalcon-debugbar-tab-label', label));
                 if (hasBadge(entry.badge)) {
                     tab.appendChild(el('span', 'phalcon-debugbar-badge', scalar(entry.badge)));
@@ -377,21 +460,31 @@
                 }
             });
 
+            var historyEntry = data.history || {};
+            historyPanel = historyEntry.panel || null;
+            historyTab = null;
+            if (historyPanel && typeof historyPanel.url === 'string') {
+                var historyWidget = widgets.history || {};
+                historyTab = el('button', 'phalcon-debugbar-tab');
+                historyTab.type = 'button';
+                historyTab.appendChild(el(
+                    'span',
+                    'phalcon-debugbar-tab-label',
+                    historyWidget.label || 'History'
+                ));
+                historyTab.addEventListener('click', function () {
+                    setHistoryOpen(!historyOpen);
+                });
+                tabs.appendChild(historyTab);
+            } else {
+                historyOpen = false;
+            }
+
             if (preferred) {
                 activate(preferred[0], preferred[1], preferred[2], preferred[3]);
             }
 
-            var historyEntry = data.history || {};
-            renderHistoryBrowser(
-                historyBrowser,
-                historyEntry.panel,
-                selectedHistoryId,
-                function (storedPayload, id) {
-                    var activeBeforeSelection = active;
-                    selectedHistoryId = id;
-                    renderData(storedPayload, activeBeforeSelection);
-                }
-            );
+            setHistoryOpen(historyOpen);
         }
 
         row.appendChild(tabs);

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -272,8 +272,16 @@
                         button.disabled = true;
                         loadJson(historyUrl(url, id)).then(function (detail) {
                             if (detail && detail.request && detail.request.payload) {
+                                Array.prototype.forEach.call(
+                                    list.querySelectorAll('.phalcon-debugbar-history-request'),
+                                    function (requestButton) {
+                                        requestButton.classList.remove('is-selected');
+                                    }
+                                );
+                                button.classList.add('is-selected');
                                 onSelect(detail.request.payload, id);
                             }
+                            button.disabled = false;
                         }).catch(function () {
                             button.disabled = false;
                         });
@@ -378,7 +386,7 @@
                 function (storedPayload, id) {
                     var activeBeforeSelection = active;
                     selectedHistoryId = id;
-                    renderData(storedPayload, activeBeforeSelection);
+                    renderData(storedPayload, activeBeforeSelection, true);
                 },
                 function () {
                     selectedHistoryId = '';
@@ -386,12 +394,17 @@
             );
         }
 
-        function setHistoryOpen(open) {
+        function setHistoryOpen(open, preserveBrowser) {
             historyOpen = Boolean(open && historyPanel);
             if (historyTab) {
                 historyTab.classList.toggle('is-active', historyOpen);
             }
-            renderOpenHistory();
+
+            if (!historyOpen) {
+                historyBrowser.style.display = 'none';
+            } else if (!preserveBrowser) {
+                renderOpenHistory();
+            }
         }
 
         function setCollapsed(collapsed) {
@@ -419,7 +432,7 @@
             active = name;
         }
 
-        function renderData(nextPayload, preferredActive) {
+        function renderData(nextPayload, preferredActive, preserveHistoryBrowser) {
             payload = nextPayload || {};
             data = payload.data || {};
             widgets = (payload.meta && payload.meta.widgets) || {};
@@ -484,7 +497,7 @@
                 activate(preferred[0], preferred[1], preferred[2], preferred[3]);
             }
 
-            setHistoryOpen(historyOpen);
+            setHistoryOpen(historyOpen, preserveHistoryBrowser);
         }
 
         row.appendChild(tabs);

--- a/resources/assets/debugbar.js
+++ b/resources/assets/debugbar.js
@@ -179,6 +179,86 @@
         return badge !== null && badge !== undefined && badge !== '' && badge !== 0;
     }
 
+    function historyUrl(url, id) {
+        if (!id) {
+            return url;
+        }
+
+        return url + (url.indexOf('?') === -1 ? '?' : '&') + 'id=' + encodeURIComponent(id);
+    }
+
+    function loadJson(url) {
+        return window.fetch(url, {
+            credentials: 'same-origin',
+            headers: {'Accept': 'application/json'}
+        }).then(function (response) {
+            if (!response.ok) {
+                throw new Error('HTTP ' + response.status);
+            }
+
+            return response.json();
+        });
+    }
+
+    function renderHistoryBrowser(mount, panel, selectedId, onSelect) {
+        mount.innerHTML = '';
+
+        var url = panel && typeof panel.url === 'string' ? panel.url : '';
+        if (!url || typeof window.fetch !== 'function') {
+            mount.style.display = 'none';
+            return;
+        }
+
+        mount.style.display = 'block';
+        mount.appendChild(el('div', 'phalcon-debugbar-history-loading', 'Loading request history...'));
+
+        loadJson(url).then(function (result) {
+            mount.innerHTML = '';
+            var requests = result && Array.isArray(result.requests) ? result.requests : [];
+            if (!requests.length) {
+                mount.appendChild(el('div', 'phalcon-debugbar-history-empty', 'No stored requests'));
+                return;
+            }
+
+            var list = el('div', 'phalcon-debugbar-history-list');
+            requests.forEach(function (request) {
+                request = request || {};
+                var id = scalar(request.id);
+                var button = el('button', 'phalcon-debugbar-history-request');
+                button.type = 'button';
+                if (id === selectedId) {
+                    button.classList.add('is-selected');
+                }
+
+                button.appendChild(el(
+                    'span',
+                    'phalcon-debugbar-history-method method-' + scalar(request.method).toLowerCase(),
+                    scalar(request.method)
+                ));
+                button.appendChild(el('span', 'phalcon-debugbar-history-uri', scalar(request.uri)));
+                button.appendChild(el('span', 'phalcon-debugbar-history-status', scalar(request.status)));
+                button.appendChild(el('time', 'phalcon-debugbar-history-time', scalar(request.requested_at)));
+
+                button.addEventListener('click', function () {
+                    button.disabled = true;
+                    loadJson(historyUrl(url, id)).then(function (detail) {
+                        if (detail && detail.request && detail.request.payload) {
+                            onSelect(detail.request.payload, id);
+                        }
+                    }).catch(function () {
+                        button.disabled = false;
+                    });
+                });
+
+                list.appendChild(button);
+            });
+            mount.appendChild(list);
+        }).catch(function () {
+            mount.innerHTML = '';
+            mount.appendChild(el('div', 'phalcon-debugbar-history-error', 'Unable to load request history'));
+        });
+    }
+
     function readCollapsed() {
         try {
             return window.localStorage.getItem(STORAGE_KEY) === '1';
@@ -213,6 +293,7 @@
         var widgets = (payload.meta && payload.meta.widgets) || {};
 
         var bar = el('div', 'phalcon-debugbar-bar');
+        var historyBrowser = el('div', 'phalcon-debugbar-history-browser');
         var body = el('div', 'phalcon-debugbar-body');
         var row = el('div', 'phalcon-debugbar-row');
         var tabs = el('div', 'phalcon-debugbar-tabs');
@@ -222,6 +303,7 @@
         body.style.display = 'none';
 
         var active = null;
+        var selectedHistoryId = '';
 
         function closePanel() {
             body.style.display = 'none';
@@ -246,41 +328,80 @@
             writeCollapsed(collapsed);
         });
 
-        Object.keys(data).forEach(function (name) {
-            var entry = data[name] || {};
-            var widget = widgets[name] || {};
-            var label = widget.label || titleize(name);
-            var type = widget.panel || inferType(entry.panel);
+        function activate(name, tab, entry, type) {
+            closePanel();
+            tab.classList.add('is-active');
+            body.innerHTML = '';
+            body.appendChild(renderPanel(type, entry.panel));
+            body.style.display = 'block';
+            active = name;
+        }
 
-            var tab = el('button', 'phalcon-debugbar-tab');
-            tab.type = 'button';
-            tab.appendChild(el('span', 'phalcon-debugbar-tab-label', label));
-            if (hasBadge(entry.badge)) {
-                tab.appendChild(el('span', 'phalcon-debugbar-badge', scalar(entry.badge)));
-            }
+        function renderData(nextPayload, preferredActive) {
+            payload = nextPayload || {};
+            data = payload.data || {};
+            widgets = (payload.meta && payload.meta.widgets) || {};
+            tabs.innerHTML = '';
+            body.innerHTML = '';
+            body.style.display = 'none';
+            active = null;
 
-            tab.addEventListener('click', function () {
-                if (active === name) {
-                    closePanel();
+            var preferred = null;
+            Object.keys(data).forEach(function (name) {
+                if (name === 'history') {
                     return;
                 }
-                closePanel();
-                tab.classList.add('is-active');
-                body.innerHTML = '';
-                body.appendChild(renderPanel(type, entry.panel));
-                body.style.display = 'block';
-                active = name;
+                var entry = data[name] || {};
+                var widget = widgets[name] || {};
+                var label = widget.label || titleize(name);
+                var type = widget.panel || inferType(entry.panel);
+
+                var tab = el('button', 'phalcon-debugbar-tab');
+                tab.type = 'button';
+                tab.appendChild(el('span', 'phalcon-debugbar-tab-label', label));
+                if (hasBadge(entry.badge)) {
+                    tab.appendChild(el('span', 'phalcon-debugbar-badge', scalar(entry.badge)));
+                }
+
+                tab.addEventListener('click', function () {
+                    if (active === name) {
+                        closePanel();
+                        return;
+                    }
+                    activate(name, tab, entry, type);
+                });
+
+                tabs.appendChild(tab);
+                if (name === preferredActive) {
+                    preferred = [name, tab, entry, type];
+                }
             });
 
-            tabs.appendChild(tab);
-        });
+            if (preferred) {
+                activate(preferred[0], preferred[1], preferred[2], preferred[3]);
+            }
+
+            var historyEntry = data.history || {};
+            renderHistoryBrowser(
+                historyBrowser,
+                historyEntry.panel,
+                selectedHistoryId,
+                function (storedPayload, id) {
+                    var activeBeforeSelection = active;
+                    selectedHistoryId = id;
+                    renderData(storedPayload, activeBeforeSelection);
+                }
+            );
+        }
 
         row.appendChild(tabs);
         row.appendChild(toggle);
+        bar.appendChild(historyBrowser);
         bar.appendChild(body);
         bar.appendChild(row);
         mount.appendChild(bar);
 
+        renderData(payload, null);
         setCollapsed(readCollapsed());
     });
 })();

--- a/src/DebugBar/Collector/HistoryCollector.php
+++ b/src/DebugBar/Collector/HistoryCollector.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\Collector;
+
+/**
+ * Enables the inline request-history browser. The browser itself is rendered
+ * by the JavaScript client; this collector only carries its internal endpoint.
+ */
+final class HistoryCollector extends AbstractCollector
+{
+    public const NAME = 'history';
+
+    /**
+     * @var string
+     */
+    protected string $icon = 'icon-history';
+
+    /**
+     * @var string
+     */
+    protected string $label = 'History';
+
+    /**
+     * @var string
+     */
+    protected string $panel = 'history';
+
+    /**
+     * @param string $url
+     */
+    public function __construct(private readonly string $url)
+    {
+    }
+
+    /**
+     * @return array{panel: array{url: string}, badge: null}
+     */
+    public function collect(): array
+    {
+        return [
+            'panel' => ['url' => $this->url],
+            'badge' => null,
+        ];
+    }
+}

--- a/src/DebugBar/Controllers/OpenHandlerController.php
+++ b/src/DebugBar/Controllers/OpenHandlerController.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\Controllers;
+
+use Phalcon\DebugBar\History\FilesystemHistory;
+use Phalcon\DebugBar\Provider;
+use Phalcon\DebugBar\Security\AccessGate;
+use Phalcon\Http\RequestInterface;
+use Phalcon\Http\ResponseInterface;
+use Phalcon\Mvc\Controller;
+use RuntimeException;
+
+use function is_string;
+use function json_encode;
+
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Internal MVC adapter for GET /_debugbar/open. Without an id it returns the
+ * current session's request list; with an id it returns the stored entry.
+ */
+final class OpenHandlerController extends Controller
+{
+    /**
+     * @return ResponseInterface
+     */
+    public function indexAction(): ResponseInterface
+    {
+        $container = $this->getDI();
+        if (null === $container) {
+            throw new RuntimeException('The OpenHandler controller requires a DI container.');
+        }
+
+        $request   = $container->getShared('request');
+        $response  = $container->getShared('response');
+        $history   = $container->getShared(Provider::HISTORY_SERVICE);
+        $access    = $container->getShared(Provider::ACCESS_GATE_SERVICE);
+
+        if (!$response instanceof ResponseInterface) {
+            throw new RuntimeException('The response service must implement ResponseInterface.');
+        }
+
+        if (
+            !$request instanceof RequestInterface
+            || !$history instanceof FilesystemHistory
+            || !$access instanceof AccessGate
+        ) {
+            return $this->json($response, ['error' => 'History is unavailable.'], 500);
+        }
+
+        $clientIp = $request->getClientAddress();
+        if (!$access->allows(is_string($clientIp) ? $clientIp : null)) {
+            return $this->json($response, ['error' => 'Not found.'], 404);
+        }
+
+        if ('GET' !== $request->getMethod()) {
+            return $this->json($response, ['error' => 'Method not allowed.'], 405);
+        }
+
+        $id = $request->getQuery('id');
+        if (!is_string($id) || '' === $id) {
+            return $this->json($response, ['requests' => $history->find()]);
+        }
+
+        $entry = $history->get($id);
+        if (null === $entry) {
+            return $this->json($response, ['error' => 'Request not found.'], 404);
+        }
+
+        return $this->json($response, ['request' => $entry]);
+    }
+
+    /**
+     * @param ResponseInterface     $response
+     * @param array<string, mixed> $body
+     * @param int                  $status
+     *
+     * @return ResponseInterface
+     */
+    private function json(ResponseInterface $response, array $body, int $status = 200): ResponseInterface
+    {
+        $json = json_encode($body, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $response->setStatusCode($status);
+        $response->setContentType('application/json', 'UTF-8');
+        $response->setHeader('Cache-Control', 'no-store, private');
+        $response->setContent(false === $json ? '{}' : $json);
+
+        return $response;
+    }
+}

--- a/src/DebugBar/Controllers/OpenHandlerController.php
+++ b/src/DebugBar/Controllers/OpenHandlerController.php
@@ -28,11 +28,49 @@ use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
 /**
- * Internal MVC adapter for GET /_debugbar/open. Without an id it returns the
- * current session's request list; with an id it returns the stored entry.
+ * Internal MVC adapter for /_debugbar/open. GET returns the current session's
+ * request list or one stored entry; DELETE clears that session's history.
  */
 final class OpenHandlerController extends Controller
 {
+    /**
+     * @return ResponseInterface
+     */
+    public function clearAction(): ResponseInterface
+    {
+        $container = $this->getDI();
+        if (null === $container) {
+            throw new RuntimeException('The OpenHandler controller requires a DI container.');
+        }
+
+        $request  = $container->getShared('request');
+        $response = $container->getShared('response');
+        $history  = $container->getShared(Provider::HISTORY_SERVICE);
+        $access   = $container->getShared(Provider::ACCESS_GATE_SERVICE);
+
+        if (!$response instanceof ResponseInterface) {
+            throw new RuntimeException('The response service must implement ResponseInterface.');
+        }
+
+        if (
+            !$request instanceof RequestInterface
+            || !$history instanceof FilesystemHistory
+            || !$access instanceof AccessGate
+        ) {
+            return $this->json($response, ['error' => 'History is unavailable.'], 500);
+        }
+
+        $clientIp = $request->getClientAddress();
+        if (!$access->allows(is_string($clientIp) ? $clientIp : null)) {
+            return $this->json($response, ['error' => 'Not found.'], 404);
+        }
+
+        if ('DELETE' !== $request->getMethod()) {
+            return $this->json($response, ['error' => 'Method not allowed.'], 405);
+        }
+
+        return $this->json($response, ['cleared' => $history->clear()]);
+    }
     /**
      * @return ResponseInterface
      */

--- a/src/DebugBar/DebugBarTypes.php
+++ b/src/DebugBar/DebugBarTypes.php
@@ -43,6 +43,13 @@ namespace Phalcon\DebugBar;
  *     access?: array{allow_ips?: list<string>, callback?: (\Closure(): bool)|null},
  *     collectors?: array<string, bool>,
  *     headers?: bool,
+ *     history?: array{
+ *         enabled?: bool,
+ *         url?: string,
+ *         path?: string,
+ *         max_requests?: int,
+ *         ttl_seconds?: int
+ *     },
  *     redact?: array{mask?: list<string>, hidden?: list<string>}
  * }
  */

--- a/src/DebugBar/History/FilesystemHistory.php
+++ b/src/DebugBar/History/FilesystemHistory.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\History;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+use function array_slice;
+use function basename;
+use function bin2hex;
+use function file_get_contents;
+use function file_put_contents;
+use function glob;
+use function hash;
+use function is_array;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function preg_match;
+use function random_bytes;
+use function rename;
+use function rsort;
+use function session_id;
+use function session_status;
+use function time;
+use function unlink;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use const LOCK_EX;
+use const PHP_SESSION_ACTIVE;
+
+/**
+ * Persists request payloads in a session-scoped directory. Callers only learn
+ * save/find/get; atomic writes, pruning, path validation, and JSON failures stay
+ * inside the module.
+ *
+ * @phpstan-import-type payload from \Phalcon\DebugBar\DebugBarTypes
+ * @phpstan-type history_meta array{
+ *     requested_at: string,
+ *     method: string,
+ *     uri: string,
+ *     status: int,
+ *     ajax: bool,
+ *     id: string,
+ *     stored_at: string
+ * }
+ * @phpstan-type history_entry array{meta: history_meta, payload: payload}
+ */
+final class FilesystemHistory
+{
+    /**
+     * @param HistoryOptions $options
+     */
+    public function __construct(private readonly HistoryOptions $options)
+    {
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function find(): array
+    {
+        $directory = $this->sessionDirectory(false);
+        if (null === $directory) {
+            return [];
+        }
+
+        $files = $this->files($directory);
+        $this->removeExpired($files);
+        $files = array_slice($this->files($directory), 0, $this->options->maxRequests);
+
+        $requests = [];
+        foreach ($files as $file) {
+            $entry = $this->read($file);
+            if (null !== $entry) {
+                $requests[] = $entry['meta'];
+            }
+        }
+
+        return $requests;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return array<string, mixed>|null
+     */
+    public function get(string $id): ?array
+    {
+        if (1 !== preg_match('/^[0-9]{14}-[0-9]{6}-[a-f0-9]{8}$/D', $id)) {
+            return null;
+        }
+
+        $directory = $this->sessionDirectory(false);
+        if (null === $directory) {
+            return null;
+        }
+
+        return $this->read($directory . '/' . basename($id) . '.json');
+    }
+
+    /**
+     * @param payload         $payload
+     * @param RequestMetadata $request
+     *
+     * @return string|null
+     */
+    public function save(array $payload, RequestMetadata $request): ?string
+    {
+        $directory = $this->sessionDirectory(true);
+        if (null === $directory) {
+            return null;
+        }
+
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $id  = $now->format('YmdHis-u-') . bin2hex(random_bytes(4));
+
+        $entry = [
+            'meta' => [
+                'requested_at' => $now->format(DATE_ATOM),
+                'method'       => $request->method,
+                'uri'          => $request->uri,
+                'status'       => $request->status,
+                'ajax'         => $request->ajax,
+                'id'           => $id,
+                'stored_at'    => $now->format(DATE_ATOM),
+            ],
+            'payload' => $payload,
+        ];
+
+        $json = json_encode($entry, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (false === $json) {
+            return null;
+        }
+
+        $target    = $directory . '/' . $id . '.json';
+        $temporary = $target . '.tmp-' . bin2hex(random_bytes(4));
+        if (false === file_put_contents($temporary, $json, LOCK_EX)) {
+            return null;
+        }
+
+        if (!rename($temporary, $target)) {
+            @unlink($temporary);
+
+            return null;
+        }
+
+        $this->prune($directory);
+
+        return $id;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return list<string>
+     */
+    private function files(string $directory): array
+    {
+        $files = glob($directory . '/*.json');
+        if (false === $files) {
+            return [];
+        }
+
+        rsort($files, SORT_STRING);
+
+        return $files;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return void
+     */
+    private function prune(string $directory): void
+    {
+        $files = $this->files($directory);
+        $this->removeExpired($files);
+
+        foreach (array_slice($this->files($directory), $this->options->maxRequests) as $file) {
+            @unlink($file);
+        }
+    }
+
+    /**
+     * @param string $file
+     *
+     * @return array{meta: array<string, mixed>, payload: array<string, mixed>}|null
+     */
+    private function read(string $file): ?array
+    {
+        if (!is_file($file)) {
+            return null;
+        }
+
+        $json = file_get_contents($file);
+        if (false === $json) {
+            return null;
+        }
+
+        $entry = json_decode($json, true);
+        if (!is_array($entry) || !is_array($entry['meta'] ?? null) || !is_array($entry['payload'] ?? null)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $meta */
+        $meta = $entry['meta'];
+        /** @var array<string, mixed> $payload */
+        $payload = $entry['payload'];
+
+        return [
+            'meta'    => $meta,
+            'payload' => $payload,
+        ];
+    }
+
+    /**
+     * @param list<string> $files
+     *
+     * @return void
+     */
+    private function removeExpired(array $files): void
+    {
+        $oldest = time() - $this->options->ttlSeconds;
+
+        foreach ($files as $file) {
+            $modified = @filemtime($file);
+            if (false !== $modified && $modified < $oldest) {
+                @unlink($file);
+            }
+        }
+    }
+
+    /**
+     * @param bool $create
+     *
+     * @return string|null
+     */
+    private function sessionDirectory(bool $create): ?string
+    {
+        if (PHP_SESSION_ACTIVE !== session_status()) {
+            return null;
+        }
+
+        $sessionId = session_id();
+        if (!is_string($sessionId) || '' === $sessionId) {
+            return null;
+        }
+
+        $directory = $this->options->path . '/' . hash('sha256', $sessionId);
+        if (is_dir($directory)) {
+            return $directory;
+        }
+
+        if (!$create || (!@mkdir($directory, 0700, true) && !is_dir($directory))) {
+            return null;
+        }
+
+        return $directory;
+    }
+}

--- a/src/DebugBar/History/FilesystemHistory.php
+++ b/src/DebugBar/History/FilesystemHistory.php
@@ -47,7 +47,7 @@ use const PHP_SESSION_ACTIVE;
 
 /**
  * Persists request payloads in a session-scoped directory. Callers only learn
- * save/find/get; atomic writes, pruning, path validation, and JSON failures stay
+ * save/find/get/clear; atomic writes, pruning, path validation, and JSON failures stay
  * inside the module.
  *
  * @phpstan-import-type payload from \Phalcon\DebugBar\DebugBarTypes
@@ -69,6 +69,28 @@ final class FilesystemHistory
      */
     public function __construct(private readonly HistoryOptions $options)
     {
+    }
+
+    /**
+     * Removes every stored request belonging to the active PHP session.
+     *
+     * @return int Number of files successfully removed.
+     */
+    public function clear(): int
+    {
+        $directory = $this->sessionDirectory(false);
+        if (null === $directory) {
+            return 0;
+        }
+
+        $removed = 0;
+        foreach ($this->files($directory) as $file) {
+            if (@unlink($file)) {
+                $removed++;
+            }
+        }
+
+        return $removed;
     }
 
     /**

--- a/src/DebugBar/History/HistoryOptions.php
+++ b/src/DebugBar/History/HistoryOptions.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\History;
+
+use function max;
+use function rtrim;
+use function sys_get_temp_dir;
+
+/**
+ * Immutable request-history configuration shared by the provider, response
+ * listener, collector, and controller.
+ */
+final class HistoryOptions
+{
+    /**
+     * @var int
+     */
+    public readonly int $maxRequests;
+
+    /**
+     * @var string
+     */
+    public readonly string $path;
+
+    /**
+     * @var int
+     */
+    public readonly int $ttlSeconds;
+
+    /**
+     * @param bool   $enabled
+     * @param string $url
+     * @param string $path
+     * @param int    $maxRequests
+     * @param int    $ttlSeconds
+     */
+    public function __construct(
+        public readonly bool $enabled = false,
+        public readonly string $url = '/_debugbar/open',
+        string $path = '',
+        int $maxRequests = 100,
+        int $ttlSeconds = 86400
+    ) {
+        $this->path        = rtrim('' !== $path ? $path : sys_get_temp_dir() . '/phalcon-debugbar', '/\\');
+        $this->maxRequests = max(1, $maxRequests);
+        $this->ttlSeconds  = max(1, $ttlSeconds);
+    }
+}

--- a/src/DebugBar/History/RequestMetadata.php
+++ b/src/DebugBar/History/RequestMetadata.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\DebugBar\History;
+
+/**
+ * The small request snapshot stored next to a collected debug-bar payload.
+ */
+final class RequestMetadata
+{
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param int    $status
+     * @param bool   $ajax
+     */
+    public function __construct(
+        public readonly string $method,
+        public readonly string $uri,
+        public readonly int $status,
+        public readonly bool $ajax
+    ) {
+    }
+}

--- a/src/DebugBar/Provider.php
+++ b/src/DebugBar/Provider.php
@@ -19,6 +19,7 @@ use Phalcon\DebugBar\Collector\CacheCollector;
 use Phalcon\DebugBar\Collector\ConfigCollector;
 use Phalcon\DebugBar\Collector\DatabaseCollector;
 use Phalcon\DebugBar\Collector\ExceptionsCollector;
+use Phalcon\DebugBar\Collector\HistoryCollector;
 use Phalcon\DebugBar\Collector\LoggerCollector;
 use Phalcon\DebugBar\Collector\MessagesCollector;
 use Phalcon\DebugBar\Collector\RequestCollector;
@@ -30,11 +31,14 @@ use Phalcon\DebugBar\Collector\ViewCollector;
 use Phalcon\DebugBar\Contracts\Collector;
 use Phalcon\DebugBar\Contracts\Subscriber;
 use Phalcon\DebugBar\Exceptions\CannotUseInProduction;
+use Phalcon\DebugBar\History\FilesystemHistory;
+use Phalcon\DebugBar\History\HistoryOptions;
 use Phalcon\DebugBar\Security\AccessGate;
 use Phalcon\DebugBar\Security\Redactor;
 use Phalcon\Di\DiInterface;
 use Phalcon\Http\RequestInterface;
 use Phalcon\Mvc\Application;
+use Phalcon\Mvc\RouterInterface;
 
 use function getenv;
 use function in_array;
@@ -44,13 +48,16 @@ use function mb_strtolower;
 /**
  * Boots the debug bar against an MVC application. Its whole coupling to the app
  * is: hold the `Application`, reach its EventsManager, and attach listeners.
- * There is no DI service to register and no container-specific wiring - the
- * app hands over its container and event bus.
+ * When request history is enabled it additionally registers an internal route
+ * and two private DI services used by its controller.
  *
  * @phpstan-import-type provider_config from DebugBarTypes
  */
 class Provider
 {
+    public const ACCESS_GATE_SERVICE = 'debugbar.accessGate';
+    public const HISTORY_SERVICE     = 'debugbar.history';
+
     /**
      * @var (Closure(): bool)|null
      */
@@ -87,6 +94,11 @@ class Provider
     private bool $headers;
 
     /**
+     * @var HistoryOptions
+     */
+    private HistoryOptions $historyOptions;
+
+    /**
      * @var string|null
      */
     private ?string $nonce;
@@ -111,6 +123,7 @@ class Provider
         $assets = $config['assets'] ?? [];
         $access = $config['access'] ?? [];
         $redact = $config['redact'] ?? [];
+        $history = $config['history'] ?? [];
 
         $this->envVar           = $env['var'] ?? 'APP_ENV';
         $this->blocked          = $env['blocked'] ?? ['production', 'prod'];
@@ -121,6 +134,13 @@ class Provider
         $this->accessCallback   = $access['callback'] ?? null;
         $this->collectorsConfig = $config['collectors'] ?? [];
         $this->headers          = $config['headers'] ?? true;
+        $this->historyOptions   = new HistoryOptions(
+            $history['enabled'] ?? false,
+            $history['url'] ?? '/_debugbar/open',
+            $history['path'] ?? '',
+            $history['max_requests'] ?? 100,
+            $history['ttl_seconds'] ?? 86400
+        );
         $this->redactor         = new Redactor(
             [...Redactor::DEFAULT_KEYS, ...($redact['mask'] ?? [])],
             $redact['hidden'] ?? []
@@ -152,12 +172,17 @@ class Provider
             return;
         }
 
-        $container = $this->app->getDI();
-        $request   = $this->resolveRequest($container);
+        $container  = $this->app->getDI();
+        $request    = $this->resolveRequest($container);
+        $accessGate = new AccessGate($this->allowedIps, $this->accessCallback);
+        $history    = $this->registerHistory($container, $accessGate);
 
         $bar = new DebugBar();
         foreach ($this->buildCollectors($container, $request) as $collector) {
             $bar->addCollector($collector);
+        }
+        if (null !== $history) {
+            $bar->addCollector(new HistoryCollector($this->historyOptions->url));
         }
 
         Debug::setBar($bar);
@@ -179,9 +204,11 @@ class Provider
                 $bar,
                 new Renderer(),
                 new Injector(),
-                new AccessGate($this->allowedIps, $this->accessCallback),
+                $accessGate,
                 $request,
-                new BarOptions($this->headers, $this->nonce)
+                new BarOptions($this->headers, $this->nonce),
+                $history,
+                null !== $history ? $this->historyOptions : null
             )
         );
     }
@@ -272,6 +299,46 @@ class Provider
     private function isCollectorEnabled(string $name): bool
     {
         return $this->collectorsConfig[$name] ?? true;
+    }
+
+    /**
+     * Registers the internal history module and its MVC route. History stays
+     * disabled when the app has no compatible container/router.
+     *
+     * @param DiInterface|null $container
+     * @param AccessGate       $accessGate
+     *
+     * @return FilesystemHistory|null
+     */
+    private function registerHistory(?DiInterface $container, AccessGate $accessGate): ?FilesystemHistory
+    {
+        if (
+            !$this->historyOptions->enabled
+            || null === $container
+            || !$container->has('router')
+        ) {
+            return null;
+        }
+
+        $router = $container->getShared('router');
+        if (!$router instanceof RouterInterface) {
+            return null;
+        }
+
+        $history = new FilesystemHistory($this->historyOptions);
+        $container->setShared(self::HISTORY_SERVICE, $history);
+        $container->setShared(self::ACCESS_GATE_SERVICE, $accessGate);
+
+        $router->addGet(
+            $this->historyOptions->url,
+            [
+                'namespace'  => 'Phalcon\\DebugBar\\Controllers',
+                'controller' => 'openHandler',
+                'action'     => 'index',
+            ]
+        )->setName('debugbar.openhandler');
+
+        return $history;
     }
 
     /**

--- a/src/DebugBar/Provider.php
+++ b/src/DebugBar/Provider.php
@@ -338,6 +338,15 @@ class Provider
             ]
         )->setName('debugbar.openhandler');
 
+        $router->addDelete(
+            $this->historyOptions->url,
+            [
+                'namespace'  => 'Phalcon\\DebugBar\\Controllers',
+                'controller' => 'openHandler',
+                'action'     => 'clear',
+            ]
+        )->setName('debugbar.clearhistory');
+
         return $history;
     }
 

--- a/src/DebugBar/ResponseListener.php
+++ b/src/DebugBar/ResponseListener.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Phalcon\DebugBar;
 
+use Phalcon\DebugBar\History\FilesystemHistory;
+use Phalcon\DebugBar\History\HistoryOptions;
+use Phalcon\DebugBar\History\RequestMetadata;
 use Phalcon\DebugBar\Security\AccessGate;
 use Phalcon\Events\EventInterface;
 use Phalcon\Http\RequestInterface;
@@ -20,6 +23,9 @@ use Phalcon\Http\ResponseInterface;
 
 use function count;
 use function is_string;
+use function parse_url;
+
+use const PHP_URL_PATH;
 
 /**
  * The `application:beforeSendResponse` listener. On the event it runs the access
@@ -27,6 +33,7 @@ use function is_string;
  * HTML response - renders and splices the bar in.
  *
  * @phpstan-import-type request_context from DebugBarTypes
+ * @phpstan-import-type payload from DebugBarTypes
  */
 final class ResponseListener
 {
@@ -44,7 +51,9 @@ final class ResponseListener
         private readonly Injector $injector,
         private readonly AccessGate $accessGate,
         private readonly ?RequestInterface $request,
-        private readonly BarOptions $options
+        private readonly BarOptions $options,
+        private readonly ?FilesystemHistory $history = null,
+        private readonly ?HistoryOptions $historyOptions = null
     ) {
     }
 
@@ -68,6 +77,8 @@ final class ResponseListener
 
         $collected = $this->bar->collect();
 
+        $this->record($collected, $response, $isAjax);
+
         if (true === $this->options->headers) {
             $response->setHeader('X-Debug-Bar', (string) count($collected['data']));
         }
@@ -79,6 +90,36 @@ final class ResponseListener
                 $this->renderer->render($collected, $this->options->nonce)
             );
         }
+    }
+
+    /**
+     * @param payload              $collected
+     * @param ResponseInterface   $response
+     * @param bool                $isAjax
+     *
+     * @return void
+     */
+    private function record(array $collected, ResponseInterface $response, bool $isAjax): void
+    {
+        if (null === $this->history || null === $this->historyOptions || null === $this->request) {
+            return;
+        }
+
+        $uri  = $this->request->getURI();
+        $path = parse_url($uri, PHP_URL_PATH);
+        if (is_string($path) && $path === $this->historyOptions->url) {
+            return;
+        }
+
+        $this->history->save(
+            $collected,
+            new RequestMetadata(
+                $this->request->getMethod(),
+                $uri,
+                $response->getStatusCode() ?? 200,
+                $isAjax
+            )
+        );
     }
 
     /**

--- a/tests/Unit/DebugBar/Collector/HistoryCollectorTest.php
+++ b/tests/Unit/DebugBar/Collector/HistoryCollectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\DebugBar\Collector;
+
+use Phalcon\DebugBar\Collector\HistoryCollector;
+use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use Phalcon\Tests\Support\DebugBar\PanelContractTrait;
+
+final class HistoryCollectorTest extends AbstractUnitTestCase
+{
+    use PanelContractTrait;
+
+    public function testCollectCarriesTheInternalEndpoint(): void
+    {
+        $collector = new HistoryCollector('/_debugbar/open');
+
+        $this->assertSame('history', $collector->getName());
+        $this->assertSame('history', $collector->getWidget()['panel']);
+        $this->assertSame(
+            ['panel' => ['url' => '/_debugbar/open'], 'badge' => null],
+            $collector->collect()
+        );
+        $this->assertPanelContract($collector);
+    }
+}

--- a/tests/Unit/DebugBar/Controllers/OpenHandlerControllerTest.php
+++ b/tests/Unit/DebugBar/Controllers/OpenHandlerControllerTest.php
@@ -47,6 +47,7 @@ final class OpenHandlerControllerTest extends AbstractUnitTestCase
         session_start();
 
         try {
+            $_SERVER['REQUEST_METHOD'] = 'GET';
             $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path));
             $id      = $history->save(
                 ['data' => [], 'meta' => ['collectors' => 0]],
@@ -74,6 +75,15 @@ final class OpenHandlerControllerTest extends AbstractUnitTestCase
             $this->assertIsArray($meta);
             $this->assertSame($id, $meta['id']);
             $this->assertSame('no-store, private', $detail->getHeaders()->get('Cache-Control'));
+
+            $_SERVER['REQUEST_METHOD'] = 'DELETE';
+            $_GET = [];
+            $clear = $this->execute($history, 'clear');
+            $this->assertSame(200, $clear->getStatusCode());
+            $clearBody = json_decode($clear->getContent(), true);
+            $this->assertIsArray($clearBody);
+            $this->assertSame(1, $clearBody['cleared']);
+            $this->assertSame([], $history->find());
         } finally {
             session_write_close();
             $directory = $path . '/' . hash('sha256', $sessionId);
@@ -89,7 +99,7 @@ final class OpenHandlerControllerTest extends AbstractUnitTestCase
         }
     }
 
-    private function execute(FilesystemHistory $history): Response
+    private function execute(FilesystemHistory $history, string $action = 'index'): Response
     {
         $container = new Di();
         $response  = new Response();
@@ -100,7 +110,11 @@ final class OpenHandlerControllerTest extends AbstractUnitTestCase
 
         $controller = new OpenHandlerController();
         $controller->setDI($container);
-        $controller->indexAction();
+        if ('clear' === $action) {
+            $controller->clearAction();
+        } else {
+            $controller->indexAction();
+        }
 
         return $response;
     }

--- a/tests/Unit/DebugBar/Controllers/OpenHandlerControllerTest.php
+++ b/tests/Unit/DebugBar/Controllers/OpenHandlerControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\DebugBar\Controllers;
+
+use Phalcon\DebugBar\Controllers\OpenHandlerController;
+use Phalcon\DebugBar\History\FilesystemHistory;
+use Phalcon\DebugBar\History\HistoryOptions;
+use Phalcon\DebugBar\History\RequestMetadata;
+use Phalcon\DebugBar\Provider;
+use Phalcon\DebugBar\Security\AccessGate;
+use Phalcon\Di\Di;
+use Phalcon\Http\Request;
+use Phalcon\Http\Response;
+use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+use function bin2hex;
+use function glob;
+use function hash;
+use function json_decode;
+use function random_bytes;
+use function session_id;
+use function session_start;
+use function session_write_close;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class OpenHandlerControllerTest extends AbstractUnitTestCase
+{
+    #[RunInSeparateProcess]
+    public function testListsAndLoadsRequestsFromTheCurrentSession(): void
+    {
+        $sessionId = 'debugbar-' . bin2hex(random_bytes(8));
+        $path      = sys_get_temp_dir() . '/phalcon-debugbar-controller-' . bin2hex(random_bytes(8));
+        session_id($sessionId);
+        session_start();
+
+        try {
+            $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path));
+            $id      = $history->save(
+                ['data' => [], 'meta' => ['collectors' => 0]],
+                new RequestMetadata('GET', '/orders', 200, false)
+            );
+            $this->assertIsString($id);
+
+            $_GET = [];
+            $list = $this->execute($history);
+            $this->assertSame(200, $list->getStatusCode());
+            $listBody = json_decode($list->getContent(), true);
+            $this->assertIsArray($listBody);
+            $requests = $listBody['requests'];
+            $this->assertIsArray($requests);
+            $this->assertCount(1, $requests);
+
+            $_GET = ['id' => $id];
+            $detail = $this->execute($history);
+            $this->assertSame(200, $detail->getStatusCode());
+            $detailBody = json_decode($detail->getContent(), true);
+            $this->assertIsArray($detailBody);
+            $request = $detailBody['request'];
+            $this->assertIsArray($request);
+            $meta = $request['meta'];
+            $this->assertIsArray($meta);
+            $this->assertSame($id, $meta['id']);
+            $this->assertSame('no-store, private', $detail->getHeaders()->get('Cache-Control'));
+        } finally {
+            session_write_close();
+            $directory = $path . '/' . hash('sha256', $sessionId);
+            $files     = glob($directory . '/*');
+            if (false !== $files) {
+                foreach ($files as $file) {
+                    unlink($file);
+                }
+            }
+
+            @rmdir($directory);
+            @rmdir($path);
+        }
+    }
+
+    private function execute(FilesystemHistory $history): Response
+    {
+        $container = new Di();
+        $response  = new Response();
+        $container->setShared('request', new Request());
+        $container->setShared('response', $response);
+        $container->setShared(Provider::HISTORY_SERVICE, $history);
+        $container->setShared(Provider::ACCESS_GATE_SERVICE, new AccessGate([], null));
+
+        $controller = new OpenHandlerController();
+        $controller->setDI($container);
+        $controller->indexAction();
+
+        return $response;
+    }
+}

--- a/tests/Unit/DebugBar/History/FilesystemHistoryTest.php
+++ b/tests/Unit/DebugBar/History/FilesystemHistoryTest.php
@@ -33,6 +33,29 @@ use function unlink;
 final class FilesystemHistoryTest extends AbstractUnitTestCase
 {
     #[RunInSeparateProcess]
+    public function testClearRemovesTheCurrentSessionsRequests(): void
+    {
+        [$path, $sessionId] = $this->startSession();
+
+        try {
+            $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path, 10, 60));
+            for ($index = 0; $index < 2; $index++) {
+                $history->save(
+                    ['data' => [], 'meta' => ['index' => $index]],
+                    new RequestMetadata('GET', '/' . $index, 200, false)
+                );
+            }
+
+            $this->assertSame(2, $history->clear());
+            $this->assertSame([], $history->find());
+            $this->assertSame(0, $history->clear());
+        } finally {
+            session_write_close();
+            $this->removeHistory($path, $sessionId);
+        }
+    }
+
+    #[RunInSeparateProcess]
     public function testMaximumRequestCountIsPruned(): void
     {
         [$path, $sessionId] = $this->startSession();
@@ -64,6 +87,7 @@ final class FilesystemHistoryTest extends AbstractUnitTestCase
             new RequestMetadata('GET', '/', 200, false)
         ));
         $this->assertSame([], $history->find());
+        $this->assertSame(0, $history->clear());
     }
     #[RunInSeparateProcess]
     public function testSaveFindAndGetAreSessionScoped(): void

--- a/tests/Unit/DebugBar/History/FilesystemHistoryTest.php
+++ b/tests/Unit/DebugBar/History/FilesystemHistoryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\DebugBar\History;
+
+use Phalcon\DebugBar\History\FilesystemHistory;
+use Phalcon\DebugBar\History\HistoryOptions;
+use Phalcon\DebugBar\History\RequestMetadata;
+use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+use function bin2hex;
+use function glob;
+use function hash;
+use function random_bytes;
+use function rmdir;
+use function session_id;
+use function session_start;
+use function session_write_close;
+use function sys_get_temp_dir;
+use function unlink;
+
+final class FilesystemHistoryTest extends AbstractUnitTestCase
+{
+    #[RunInSeparateProcess]
+    public function testMaximumRequestCountIsPruned(): void
+    {
+        [$path, $sessionId] = $this->startSession();
+
+        try {
+            $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path, 2, 60));
+            for ($index = 0; $index < 3; $index++) {
+                $history->save(
+                    ['data' => [], 'meta' => ['index' => $index]],
+                    new RequestMetadata('GET', '/' . $index, 200, false)
+                );
+            }
+
+            $this->assertCount(2, $history->find());
+        } finally {
+            session_write_close();
+            $this->removeHistory($path, $sessionId);
+        }
+    }
+
+    #[RunInSeparateProcess]
+    public function testNoActiveSessionStoresNothing(): void
+    {
+        $path    = $this->temporaryPath();
+        $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path));
+
+        $this->assertNull($history->save(
+            ['data' => [], 'meta' => []],
+            new RequestMetadata('GET', '/', 200, false)
+        ));
+        $this->assertSame([], $history->find());
+    }
+    #[RunInSeparateProcess]
+    public function testSaveFindAndGetAreSessionScoped(): void
+    {
+        [$path, $sessionId] = $this->startSession();
+
+        try {
+            $history = new FilesystemHistory(new HistoryOptions(true, '/_debugbar/open', $path, 10, 60));
+            $id      = $history->save(
+                ['data' => [], 'meta' => ['collectors' => 0]],
+                new RequestMetadata('POST', '/orders', 201, true)
+            );
+
+            $this->assertIsString($id);
+
+            $requests = $history->find();
+            $this->assertCount(1, $requests);
+            $this->assertSame($id, $requests[0]['id']);
+            $this->assertSame('POST', $requests[0]['method']);
+            $this->assertSame('/orders', $requests[0]['uri']);
+            $this->assertSame(201, $requests[0]['status']);
+            $this->assertTrue($requests[0]['ajax']);
+
+            $entry = $history->get($id);
+            $this->assertIsArray($entry);
+            $payload = $entry['payload'];
+            $this->assertIsArray($payload);
+            $meta = $payload['meta'];
+            $this->assertIsArray($meta);
+            $this->assertSame(0, $meta['collectors']);
+            $this->assertNull($history->get('../outside'));
+        } finally {
+            session_write_close();
+            $this->removeHistory($path, $sessionId);
+        }
+    }
+
+    private function removeHistory(string $path, string $sessionId): void
+    {
+        $directory = $path . '/' . hash('sha256', $sessionId);
+        $files     = glob($directory . '/*');
+        if (false !== $files) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
+
+        @rmdir($directory);
+        @rmdir($path);
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function startSession(): array
+    {
+        $sessionId = 'debugbar-' . bin2hex(random_bytes(8));
+        session_id($sessionId);
+        session_start();
+
+        return [$this->temporaryPath(), $sessionId];
+    }
+
+    private function temporaryPath(): string
+    {
+        return sys_get_temp_dir() . '/phalcon-debugbar-test-' . bin2hex(random_bytes(8));
+    }
+}

--- a/tests/Unit/DebugBar/ProviderTest.php
+++ b/tests/Unit/DebugBar/ProviderTest.php
@@ -282,6 +282,13 @@ final class ProviderTest extends AbstractUnitTestCase
         }
 
         $this->assertSame('/_debugbar/open', $route->getPattern());
+
+        $clearRoute = $router->getRouteByName('debugbar.clearhistory');
+        if (!$clearRoute instanceof RouteInterface) {
+            $this->fail('Expected the debugbar.clearhistory route.');
+        }
+
+        $this->assertSame('/_debugbar/open', $clearRoute->getPattern());
     }
 
     #[RunInSeparateProcess]

--- a/tests/Unit/DebugBar/ProviderTest.php
+++ b/tests/Unit/DebugBar/ProviderTest.php
@@ -19,17 +19,24 @@ use Phalcon\DebugBar\DebugBar;
 use Phalcon\DebugBar\Exceptions\CannotUseInProduction;
 use Phalcon\DebugBar\Provider;
 use Phalcon\Di\Di;
+use Phalcon\Di\FactoryDefault;
 use Phalcon\Events\Manager;
 use Phalcon\Http\Request;
 use Phalcon\Http\Response;
+use Phalcon\Http\ResponseInterface;
 use Phalcon\Mvc\Application;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use stdClass;
 
 use function array_keys;
 use function is_array;
+use function json_decode;
 use function putenv;
+use function sys_get_temp_dir;
 
 #[BackupGlobals(true)]
 final class ProviderTest extends AbstractUnitTestCase
@@ -246,6 +253,68 @@ final class ProviderTest extends AbstractUnitTestCase
         $em->fire('application:beforeSendResponse', $app, $response);
 
         $this->assertFalse($response->getHeaders()->has('X-Debug-Bar'));
+    }
+
+    public function testHistoryRegistersItsCollectorRouteAndServices(): void
+    {
+        $_ENV[self::ENV_VAR] = 'dev';
+        $em                  = new Manager();
+        $router              = new Router(false);
+        $app                 = $this->applicationWithServices($em, [
+            'request'  => new Request(),
+            'response' => new Response(),
+            'router'   => $router,
+        ]);
+
+        (new Provider($app, [
+            'env'     => ['var' => self::ENV_VAR],
+            'history' => ['enabled' => true, 'path' => 'var/debugbar'],
+        ]))->boot();
+
+        $container = $app->getDI();
+        $this->assertNotNull($container);
+        $this->assertTrue($container->has(Provider::HISTORY_SERVICE));
+        $this->assertTrue($container->has(Provider::ACCESS_GATE_SERVICE));
+        $this->assertTrue($this->bootedBar()->hasCollector('history'));
+        $route = $router->getRouteByName('debugbar.openhandler');
+        if (!$route instanceof RouteInterface) {
+            $this->fail('Expected the debugbar.openhandler route.');
+        }
+
+        $this->assertSame('/_debugbar/open', $route->getPattern());
+    }
+
+    #[RunInSeparateProcess]
+    public function testHistoryRouteDispatchesTheInternalController(): void
+    {
+        $_ENV[self::ENV_VAR]          = 'dev';
+        $_SERVER['REQUEST_METHOD']    = 'GET';
+        $_SERVER['REQUEST_URI']       = '/_debugbar/open';
+        $_SERVER['REMOTE_ADDR']       = '127.0.0.1';
+
+        $container = new FactoryDefault();
+        $app       = new Application($container);
+        $app->useImplicitView(false);
+        $app->setEventsManager(new Manager());
+
+        (new Provider($app, [
+            'env'     => ['var' => self::ENV_VAR],
+            'history' => [
+                'enabled' => true,
+                'path'    => sys_get_temp_dir() . '/phalcon-debugbar-routing',
+            ],
+        ]))->boot();
+
+        $response = $app->handle('/_debugbar/open');
+        if (!$response instanceof ResponseInterface) {
+            $this->fail('Expected the history route to return a response.');
+        }
+
+        $body = json_decode($response->getContent(), true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['requests' => []], $body);
+        $this->assertSame('application/json; charset=UTF-8', $response->getHeaders()->get('Content-Type'));
     }
 
     public function testIsAllowedTracksTheEnvironment(): void

--- a/tests/support/DebugBar/PanelContractTrait.php
+++ b/tests/support/DebugBar/PanelContractTrait.php
@@ -71,6 +71,12 @@ trait PanelContractTrait
                 Assert::assertIsString($data);
 
                 break;
+            case 'history':
+                Assert::assertIsArray($data);
+                Assert::assertArrayHasKey('url', $data);
+                Assert::assertIsString($data['url']);
+
+                break;
             default:
                 Assert::fail('Unknown panel type: ' . $panel);
         }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #21

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/debugbar/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a separate PR for the documentation (the documentation is included in this PR)

Small description of change:

This PR adds an optional, session-scoped request history system to the debug bar.

It resolves #21, which describes the current limitation where the bar can only inspect the request that rendered the current page. This makes completed AJAX requests, redirects, and earlier requests difficult to inspect once they have finished.

Closes #21.

When enabled, the new history system records the collected debug-bar payload together with request metadata such as:

- HTTP method
- URI
- response status
- AJAX flag
- request timestamp

A new `History` item in the bottom bar opens the list of stored requests. Selecting a request replaces the currently displayed collector data without navigating away from or reloading the host page. The history browser also provides refresh and clear controls.

### Storage and retention

History storage is disabled by default and must be enabled explicitly through configuration.

Stored requests are:

- isolated by a SHA-256 hash of the active PHP session ID
- written atomically to a configurable filesystem directory
- limited by a configurable maximum request count
- automatically removed after a configurable TTL
- not recorded or exposed when no PHP session is active

The storage path defaults to the system temporary directory and can be configured outside the application document root.

### Internal endpoint

When history is enabled, the provider automatically registers an internal controller for:

- `GET /_debugbar/open` - list stored request metadata
- `GET /_debugbar/open?id=<request-id>` - load a stored debug-bar payload
- `DELETE /_debugbar/open` - clear the current session's history

The endpoint reuses the debug bar access gate, returns private non-cacheable responses, validates request IDs, and excludes its own requests from the history.

### Backward compatibility

The feature is opt-in. Existing applications retain the current behavior when `history.enabled` is not enabled.

### Tests

The PR includes tests covering:

- session isolation
- filesystem persistence
- maximum request pruning
- TTL expiration
- request lookup and validation
- clearing stored requests
- the internal controller
- provider route registration
- the history collector

Thanks